### PR TITLE
Fixes for updating cache

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog
 1.4.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Remove mailchimp object before updating cache.  Otherwise a change
+  in the api key is not picked up until after a restart.
+  [maurits]
 
 
 1.4.0 (2015-04-29)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 1.4.1 (unreleased)
 ------------------
 
+- Try to avoid some needless registry updates.
+  [maurits]
+
 - Disable inline validation in the mailchimp control panel.  It may
   change the cache based on a new api key that the user has not yet
   saved.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ Changelog
 1.4.1 (unreleased)
 ------------------
 
+- Disable inline validation in the mailchimp control panel.  It may
+  change the cache based on a new api key that the user has not yet
+  saved.
+  [maurits]
+
 - Remove mailchimp object before updating cache.  Otherwise a change
   in the api key is not picked up until after a restart.
   [maurits]

--- a/collective/mailchimp/browser/controlpanel.pt
+++ b/collective/mailchimp/browser/controlpanel.pt
@@ -172,6 +172,12 @@
       </fieldset>
     </div>
 
+    <script type="text/javascript">
+// Disable inline validation.  It may change the cache based on a new
+// api key that the user has not yet saved.
+$('.z3cformInlineValidation').removeClass('z3cformInlineValidation');
+    </script>
+
   </div>
 </body>
 </html>

--- a/collective/mailchimp/locator.py
+++ b/collective/mailchimp/locator.py
@@ -130,6 +130,12 @@ class MailchimpLocator(object):
             return None
 
     def updateCache(self):
+        # Update cache of data from the mailchimp server.  First reset
+        # our mailchimp object, as the user may have picked a
+        # different api key.  Alternatively, compare
+        # self.settings.api_key and self.mailchimp.apikey.
+        self.mailchimp = None
+        # Connecting will recreate the mailchimp object.
         self.connect()
         if not self.settings.api_key:
             return

--- a/collective/mailchimp/locator.py
+++ b/collective/mailchimp/locator.py
@@ -139,6 +139,9 @@ class MailchimpLocator(object):
         self.connect()
         if not self.settings.api_key:
             return
+        # Note that we must call the _underscore methods.  These
+        # bypass the cache and go directly to mailchimp, so we are
+        # certain to have up to date information.
         account = self._account()
         groups = {}
         lists = self._lists()
@@ -146,10 +149,22 @@ class MailchimpLocator(object):
             list_id = mailchimp_list['id']
             groups[list_id] = self._groups(list_id=list_id)
 
-        # now save this to the registry
+        # Now save this to the registry, but only if there are
+        # changes, otherwise we would do a commit every time we look
+        # at the control panel.
         if type(account) is dict:
-            self.registry[self.key_account] = account
+            if self.registry[self.key_account] != account:
+                self.registry[self.key_account] = account
         if type(groups) is dict:
-            self.registry[self.key_groups] = groups
+            if self.registry[self.key_groups] != groups:
+                self.registry[self.key_groups] = groups
         if type(lists) is list:
-            self.registry[self.key_lists] = tuple(lists)
+            lists = tuple(lists)
+            if self.registry[self.key_lists] != lists:
+                # Note that unfortunately this happens far too often.
+                # In the 'subscribe_url_long' key of an item you can
+                # easily first see:
+                # 'http://edata.us3.list-manage.com/subscribe?u=abc123',
+                # and a second later:
+                # 'http://edata.us3.list-manage1.com/subscribe?u=abc123',
+                self.registry[self.key_lists] = lists

--- a/collective/mailchimp/testing.py
+++ b/collective/mailchimp/testing.py
@@ -73,7 +73,7 @@ class CollectiveMailchimp(PloneSandboxLayer):
         # Get account details
         mailchimp.getAccountDetails()
         mocker.count(0, 1000)
-        mocker.result([])
+        mocker.result({})
         result = {  # noqa
             u'total': 1,
             u'data': [{

--- a/collective/mailchimp/tests/test_locator.py
+++ b/collective/mailchimp/tests/test_locator.py
@@ -40,6 +40,32 @@ class MailchimpLocatorIntegrationTest(unittest.TestCase):
         self.assertEqual(
             len(locator.groups(list_id=u'a1346945ab')['groups']), 3)
 
+    def test_mailchimp_locator_updateCache_method(self):
+        from collective.mailchimp.locator import MailchimpLocator
+        locator = MailchimpLocator()
+        locator.initialize()
+        # These tests pass when we run this test method separately,
+        # but fail when running all tests.  Skip them because they are
+        # not what we really want to test here.
+        #
+        # self.assertEqual(locator.registry[locator.key_account], None)
+        # self.assertEqual(locator.registry[locator.key_groups], None)
+        # self.assertEqual(locator.registry[locator.key_lists], None)
+        locator.updateCache()
+        self.assertTrue(
+            isinstance(locator.registry[locator.key_account], dict))
+        self.assertEqual(locator.registry[locator.key_account], {})
+        self.assertTrue(
+            isinstance(locator.registry[locator.key_groups], dict))
+        self.assertEqual(locator.registry[locator.key_groups].keys(),
+                         [u'f6257645gs', u'f6267645gs'])
+        self.assertTrue(
+            isinstance(locator.registry[locator.key_lists], tuple))
+        self.assertEqual(len(locator.registry[locator.key_lists]), 2)
+        # It does not complain when there is no api key
+        locator.settings.api_key = None
+        locator.updateCache()
+
 
 def test_suite():
     return unittest.defaultTestLoader.loadTestsFromName(__name__)


### PR DESCRIPTION
First commit is the most important. I was getting a report from a client that he had changed the api key and that the changes (other lists) were only visible after a restart.