### PR TITLE
Use Mailchimp api 3.0 and support Plone 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
     - PLONE=4
     - PLONE=5
 install:
-  - sed -ie "s#plone5.cfg#plone$PLONE_MAJOR_VERSION.cfg#" buildout.cfg
+  - sed -ie "s#plone5.cfg#plone$PLONE.cfg#" buildout.cfg
   - python bootstrap.py -c travis.cfg
   - bin/buildout -N -t 3 -c travis.cfg
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,11 @@ env:
     - PLONE=5
 install:
   - sed -ie "s#plone5.cfg#plone$PLONE.cfg#" buildout.cfg
-  - python bootstrap.py -c travis.cfg
+# Keep setuptools and zc.buildout the synced with buildout.cfg,
+# otherwise the buildout fails due to the non newest ('-N') option
+# when it wants to downgrade one of them to the pinned version.
+  - python bootstrap.py -c travis.cfg --buildout-version=2.5.0 --setuptools-version=19.4
+  - bin/buildout -c travis.cfg annotate
   - bin/buildout -N -t 3 -c travis.cfg
 script:
   - bin/code-analysis

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,12 @@ sudo: false
 cache:
   directories:
   - eggs
+env:
+  matrix:
+    - PLONE=4
+    - PLONE=5
 install:
+  - sed -ie "s#plone5.cfg#plone$PLONE_MAJOR_VERSION.cfg#" buildout.cfg
   - python bootstrap.py -c travis.cfg
   - bin/buildout -N -t 3 -c travis.cfg
 script:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 1.4.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Remove bare excepts.
+  [timo]
 
 
 1.4.1 (2015-05-04)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Changelog
 1.4.2 (unreleased)
 ------------------
 
+- Added support for Plone 5, kept 4.3 compatibility.  [jladage, didrix, maurits]
+
+- Updated to version 3.0 of the mailchimp api.  [jladage, didrix, maurits]
+
 - Remove bare excepts.
   [timo]
 

--- a/TODO.txt
+++ b/TODO.txt
@@ -1,6 +1,4 @@
 TODO
 ====
 
-  [ ] Move from mocker to mock for unit tests.
-
   [ ] 100% test coverage.

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -18,75 +18,17 @@ The script accepts buildout command-line options, so you can
 use the -c option to specify an alternate configuration file.
 """
 
-import os, shutil, sys, tempfile, urllib, urllib2, subprocess
+import os
+import shutil
+import sys
+import tempfile
+
 from optparse import OptionParser
 
-if sys.platform == 'win32':
-    def quote(c):
-        if ' ' in c:
-            return '"%s"' % c  # work around spawn lamosity on windows
-        else:
-            return c
-else:
-    quote = str
+__version__ = '2015-07-01'
+# See zc.buildout's changelog if this version is up to date.
 
-# See zc.buildout.easy_install._has_broken_dash_S for motivation and comments.
-stdout, stderr = subprocess.Popen(
-    [sys.executable, '-Sc',
-     'try:\n'
-     '    import ConfigParser\n'
-     'except ImportError:\n'
-     '    print 1\n'
-     'else:\n'
-     '    print 0\n'],
-    stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()
-has_broken_dash_S = bool(int(stdout.strip()))
-
-# In order to be more robust in the face of system Pythons, we want to
-# run without site-packages loaded.  This is somewhat tricky, in
-# particular because Python 2.6's distutils imports site, so starting
-# with the -S flag is not sufficient.  However, we'll start with that:
-if not has_broken_dash_S and 'site' in sys.modules:
-    # We will restart with python -S.
-    args = sys.argv[:]
-    args[0:0] = [sys.executable, '-S']
-    args = map(quote, args)
-    os.execv(sys.executable, args)
-# Now we are running with -S.  We'll get the clean sys.path, import site
-# because distutils will do it later, and then reset the path and clean
-# out any namespace packages from site-packages that might have been
-# loaded by .pth files.
-clean_path = sys.path[:]
-import site  # imported because of its side effects
-sys.path[:] = clean_path
-for k, v in sys.modules.items():
-    if k in ('setuptools', 'pkg_resources') or (
-        hasattr(v, '__path__') and
-        len(v.__path__) == 1 and
-        not os.path.exists(os.path.join(v.__path__[0], '__init__.py'))):
-        # This is a namespace package.  Remove it.
-        sys.modules.pop(k)
-
-is_jython = sys.platform.startswith('java')
-
-setuptools_source = 'http://peak.telecommunity.com/dist/ez_setup.py'
-distribute_source = 'http://python-distribute.org/distribute_setup.py'
-
-
-# parsing arguments
-def normalize_to_url(option, opt_str, value, parser):
-    if value:
-        if '://' not in value:  # It doesn't smell like a URL.
-            value = 'file://%s' % (
-                urllib.pathname2url(
-                    os.path.abspath(os.path.expanduser(value))),)
-        if opt_str == '--download-base' and not value.endswith('/'):
-            # Download base needs a trailing slash to make the world happy.
-            value += '/'
-    else:
-        value = None
-    name = opt_str[2:].replace('-', '_')
-    setattr(parser.values, name, value)
+tmpeggs = tempfile.mkdtemp(prefix='bootstrap-')
 
 usage = '''\
 [DESIRED PYTHON FOR BUILDOUT] bootstrap.py [options]
@@ -96,31 +38,14 @@ Bootstraps a buildout-based project.
 Simply run this script in a directory containing a buildout.cfg, using the
 Python that you want bin/buildout to use.
 
-Note that by using --setup-source and --download-base to point to
-local resources, you can keep this script from going over the network.
+Note that by using --find-links to point to local resources, you can keep
+this script from going over the network.
 '''
 
 parser = OptionParser(usage=usage)
-parser.add_option("-v", "--version", dest="version",
-                          help="use a specific zc.buildout version")
-parser.add_option("-d", "--distribute",
-                   action="store_true", dest="use_distribute", default=False,
-                   help="Use Distribute rather than Setuptools.")
-parser.add_option("--setup-source", action="callback", dest="setup_source",
-                  callback=normalize_to_url, nargs=1, type="string",
-                  help=("Specify a URL or file location for the setup file. "
-                        "If you use Setuptools, this will default to " +
-                        setuptools_source + "; if you use Distribute, this "
-                        "will default to " + distribute_source + "."))
-parser.add_option("--download-base", action="callback", dest="download_base",
-                  callback=normalize_to_url, nargs=1, type="string",
-                  help=("Specify a URL or directory for downloading "
-                        "zc.buildout and either Setuptools or Distribute. "
-                        "Defaults to PyPI."))
-parser.add_option("--eggs",
-                  help=("Specify a directory for storing eggs.  Defaults to "
-                        "a temporary directory that is deleted when the "
-                        "bootstrap script completes."))
+parser.add_option("--version",
+                  action="store_true", default=False,
+                  help=("Return bootstrap.py version."))
 parser.add_option("-t", "--accept-buildout-test-releases",
                   dest='accept_buildout_test_releases',
                   action="store_true", default=False,
@@ -130,95 +55,117 @@ parser.add_option("-t", "--accept-buildout-test-releases",
                         "extensions for you.  If you use this flag, "
                         "bootstrap and buildout will get the newest releases "
                         "even if they are alphas or betas."))
-parser.add_option("-c", None, action="store", dest="config_file",
-                   help=("Specify the path to the buildout configuration "
-                         "file to be used."))
+parser.add_option("-c", "--config-file",
+                  help=("Specify the path to the buildout configuration "
+                        "file to be used."))
+parser.add_option("-f", "--find-links",
+                  help=("Specify a URL to search for buildout releases"))
+parser.add_option("--allow-site-packages",
+                  action="store_true", default=False,
+                  help=("Let bootstrap.py use existing site packages"))
+parser.add_option("--buildout-version",
+                  help="Use a specific zc.buildout version")
+parser.add_option("--setuptools-version",
+                  help="Use a specific setuptools version")
+parser.add_option("--setuptools-to-dir",
+                  help=("Allow for re-use of existing directory of "
+                        "setuptools versions"))
 
 options, args = parser.parse_args()
+if options.version:
+    print("bootstrap.py version %s" % __version__)
+    sys.exit(0)
 
-if options.eggs:
-    eggs_dir = os.path.abspath(os.path.expanduser(options.eggs))
-else:
-    eggs_dir = tempfile.mkdtemp()
 
-if options.setup_source is None:
-    if options.use_distribute:
-        options.setup_source = distribute_source
-    else:
-        options.setup_source = setuptools_source
-
-if options.accept_buildout_test_releases:
-    args.insert(0, 'buildout:accept-buildout-test-releases=true')
+######################################################################
+# load/install setuptools
 
 try:
-    import pkg_resources
-    import setuptools  # A flag.  Sometimes pkg_resources is installed alone.
-    if not hasattr(pkg_resources, '_distribute'):
-        raise ImportError
+    from urllib.request import urlopen
 except ImportError:
-    ez_code = urllib2.urlopen(
-        options.setup_source).read().replace('\r\n', '\n')
-    ez = {}
-    exec ez_code in ez
-    setup_args = dict(to_dir=eggs_dir, download_delay=0)
-    if options.download_base:
-        setup_args['download_base'] = options.download_base
-    if options.use_distribute:
-        setup_args['no_fake'] = True
-        if sys.version_info[:2] == (2, 4):
-            setup_args['version'] = '0.6.32'
-    ez['use_setuptools'](**setup_args)
-    if 'pkg_resources' in sys.modules:
-        reload(sys.modules['pkg_resources'])
-    import pkg_resources
-    # This does not (always?) update the default working set.  We will
-    # do it.
-    for path in sys.path:
-        if path not in pkg_resources.working_set.entries:
-            pkg_resources.working_set.add_entry(path)
+    from urllib2 import urlopen
 
-cmd = [quote(sys.executable),
-       '-c',
-       quote('from setuptools.command.easy_install import main; main()'),
-       '-mqNxd',
-       quote(eggs_dir)]
-
-if not has_broken_dash_S:
-    cmd.insert(1, '-S')
-
-find_links = options.download_base
-if not find_links:
-    find_links = os.environ.get('bootstrap-testing-find-links')
-if not find_links and options.accept_buildout_test_releases:
-    find_links = 'http://downloads.buildout.org/'
-if find_links:
-    cmd.extend(['-f', quote(find_links)])
-
-if options.use_distribute:
-    setup_requirement = 'distribute'
+ez = {}
+if os.path.exists('ez_setup.py'):
+    exec(open('ez_setup.py').read(), ez)
 else:
-    setup_requirement = 'setuptools'
+    exec(urlopen('https://bootstrap.pypa.io/ez_setup.py').read(), ez)
+
+if not options.allow_site_packages:
+    # ez_setup imports site, which adds site packages
+    # this will remove them from the path to ensure that incompatible versions
+    # of setuptools are not in the path
+    import site
+    # inside a virtualenv, there is no 'getsitepackages'.
+    # We can't remove these reliably
+    if hasattr(site, 'getsitepackages'):
+        for sitepackage_path in site.getsitepackages():
+            # Strip all site-packages directories from sys.path that
+            # are not sys.prefix; this is because on Windows
+            # sys.prefix is a site-package directory.
+            if sitepackage_path != sys.prefix:
+                sys.path[:] = [x for x in sys.path
+                               if sitepackage_path not in x]
+
+setup_args = dict(to_dir=tmpeggs, download_delay=0)
+
+if options.setuptools_version is not None:
+    setup_args['version'] = options.setuptools_version
+if options.setuptools_to_dir is not None:
+    setup_args['to_dir'] = options.setuptools_to_dir
+
+ez['use_setuptools'](**setup_args)
+import setuptools
+import pkg_resources
+
+# This does not (always?) update the default working set.  We will
+# do it.
+for path in sys.path:
+    if path not in pkg_resources.working_set.entries:
+        pkg_resources.working_set.add_entry(path)
+
+######################################################################
+# Install buildout
+
 ws = pkg_resources.working_set
-setup_requirement_path = ws.find(
-    pkg_resources.Requirement.parse(setup_requirement)).location
-env = dict(
-    os.environ,
-    PYTHONPATH=setup_requirement_path)
+
+setuptools_path = ws.find(
+    pkg_resources.Requirement.parse('setuptools')).location
+
+# Fix sys.path here as easy_install.pth added before PYTHONPATH
+cmd = [sys.executable, '-c',
+       'import sys; sys.path[0:0] = [%r]; ' % setuptools_path +
+       'from setuptools.command.easy_install import main; main()',
+       '-mZqNxd', tmpeggs]
+
+find_links = os.environ.get(
+    'bootstrap-testing-find-links',
+    options.find_links or
+    ('http://downloads.buildout.org/'
+     if options.accept_buildout_test_releases else None)
+    )
+if find_links:
+    cmd.extend(['-f', find_links])
 
 requirement = 'zc.buildout'
-version = options.version
+version = options.buildout_version
 if version is None and not options.accept_buildout_test_releases:
     # Figure out the most recent final version of zc.buildout.
     import setuptools.package_index
     _final_parts = '*final-', '*final'
 
     def _final_version(parsed_version):
-        for part in parsed_version:
-            if (part[:1] == '*') and (part not in _final_parts):
-                return False
-        return True
+        try:
+            return not parsed_version.is_prerelease
+        except AttributeError:
+            # Older setuptools
+            for part in parsed_version:
+                if (part[:1] == '*') and (part not in _final_parts):
+                    return False
+            return True
+
     index = setuptools.package_index.PackageIndex(
-        search_path=[setup_requirement_path])
+        search_path=[setuptools_path])
     if find_links:
         index.add_find_links((find_links,))
     req = pkg_resources.Requirement.parse(requirement)
@@ -227,8 +174,6 @@ if version is None and not options.accept_buildout_test_releases:
         bestv = None
         for dist in index[req.project_name]:
             distv = dist.parsed_version
-            if distv >= pkg_resources.parse_version('2dev'):
-                continue
             if _final_version(distv):
                 if bestv is None or distv > bestv:
                     best = [dist]
@@ -238,40 +183,28 @@ if version is None and not options.accept_buildout_test_releases:
         if best:
             best.sort()
             version = best[-1].version
-
 if version:
-    requirement += '=='+version
-else:
-    requirement += '<2dev'
-
+    requirement = '=='.join((requirement, version))
 cmd.append(requirement)
 
-if is_jython:
-    import subprocess
-    exitcode = subprocess.Popen(cmd, env=env).wait()
-else:  # Windows prefers this, apparently; otherwise we would prefer subprocess
-    exitcode = os.spawnle(*([os.P_WAIT, sys.executable] + cmd + [env]))
-if exitcode != 0:
-    sys.stdout.flush()
-    sys.stderr.flush()
-    print ("An error occurred when trying to install zc.buildout. "
-           "Look above this message for any errors that "
-           "were output by easy_install.")
-    sys.exit(exitcode)
+import subprocess
+if subprocess.call(cmd) != 0:
+    raise Exception(
+        "Failed to execute command:\n%s" % repr(cmd)[1:-1])
 
-ws.add_entry(eggs_dir)
+######################################################################
+# Import and run buildout
+
+ws.add_entry(tmpeggs)
 ws.require(requirement)
 import zc.buildout.buildout
 
-# If there isn't already a command in the args, add bootstrap
 if not [a for a in args if '=' not in a]:
     args.append('bootstrap')
 
-
-# if -c was provided, we push it back into args for buildout's main function
+# if -c was provided, we push it back into args for buildout' main function
 if options.config_file is not None:
     args[0:0] = ['-c', options.config_file]
 
 zc.buildout.buildout.main(args)
-if not options.eggs:  # clean up temporary egg directory
-    shutil.rmtree(eggs_dir)
+shutil.rmtree(tmpeggs)

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,5 +1,5 @@
 [buildout]
-extends = http://dist.plone.org/release/4.3.4/versions.cfg
+extends = http://dist.plone.org/release/5.0/versions.cfg
 
 develop = .
 eggs = collective.mailchimp

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,6 +1,6 @@
 [buildout]
+# Note that the extends config is replaced in .travis.yml.
 extends = plone5.cfg
-
 develop = .
 eggs = collective.mailchimp
 parts +=
@@ -116,3 +116,6 @@ mode = 755
 
 [versions]
 coverage = 3.7.1
+# Keep setuptools and zc.buildout the synced with .travis.yml
+setuptools = 19.4
+zc.buildout = 2.5.0

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,5 +1,5 @@
 [buildout]
-extends = http://dist.plone.org/release/4.3.7/versions.cfg
+extends = plone5.cfg
 
 develop = .
 eggs = collective.mailchimp
@@ -116,4 +116,3 @@ mode = 755
 
 [versions]
 coverage = 3.7.1
-plone.app.linkintegrity = 1.5.4

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,5 +1,5 @@
 [buildout]
-extends = http://dist.plone.org/release/5.0/versions.cfg
+extends = http://dist.plone.org/release/4.3.7/versions.cfg
 
 develop = .
 eggs = collective.mailchimp

--- a/collective/mailchimp/browser/controlpanel.pt
+++ b/collective/mailchimp/browser/controlpanel.pt
@@ -49,47 +49,23 @@
           <tbody>
             <tr>
                <td i18n:translate="">Username:</td>
-               <td tal:content="account/username|empty"/>
-            </tr>
-            <tr>
-              <td i18n:translate="">E-mails left: </td>
-              <td tal:content="account/emails_left|empty"/>
-            </tr>
-            <tr>
-              <td i18n:translate="">Member since: </td>
-              <td tal:content="account/member_since|empty"/>
+               <td tal:content="account/account_name|empty"/>
             </tr>
             <tr>
               <td i18n:translate="">Last login: </td>
               <td tal:content="account/last_login|empty"/>
             </tr>
             <tr>
-              <td i18n:translate="">Plan type: </td>
-              <td tal:content="account/plan_type|empty"/>
-            </tr>
-            <tr>
               <td i18n:translate="">Company: </td>
               <td tal:content="account/contact/company|empty"/>
             </tr>
             <tr>
-              <td i18n:translate="">First name: </td>
-              <td tal:content="account/contact/fname|empty"/>
-            </tr>
-            <tr>
-              <td i18n:translate="">Last name: </td>
-              <td tal:content="account/contact/lname|empty"/>
-            </tr>
-            <tr>
-              <td i18n:translate="">Email: </td>
-              <td tal:content="account/contact/email|empty"/>
-            </tr>
-            <tr>
               <td i18n:translate="">Address 1: </td>
-              <td tal:content="account/contact/address1|empty"/>
+              <td tal:content="account/contact/addr1|empty"/>
             </tr>
             <tr>
               <td i18n:translate="">Address 2: </td>
-              <td tal:content="account/contact/address2|empty"/>
+              <td tal:content="account/contact/addr2|empty"/>
             </tr>
             <tr>
               <td i18n:translate="">Zip: </td>
@@ -107,19 +83,7 @@
               <td i18n:translate="">Country: </td>
               <td tal:content="account/contact/country|empty"/>
             </tr>
-            <tr>
-              <td i18n:translate="">URL: </td>
-              <td tal:content="account/contact/url|empty"/>
-            </tr>
-            <tr>
-              <td i18n:translate="">Phone: </td>
-              <td tal:content="account/contact/phone|empty"/>
-            </tr>
-            <tr>
-              <td i18n:translate="">Fax: </td>
-              <td tal:content="account/contact/fax|empty"/>
-            </tr>
-          </tbody>
+           </tbody>
         </table>
 
       </fieldset>
@@ -130,41 +94,37 @@
           <thead>
             <tr>
               <th i18n:translate="">ID</th>
-              <th i18n:translate="">Web ID</th>
               <th i18n:translate="">Name</th>
               <th i18n:translate="">Member count</th>
-              <th i18n:translate="">Email type option</th>
               <th i18n:translate="">Member count since send</th>
-              <th i18n:translate="">Default language</th>
               <th i18n:translate="">Default from name</th>
-              <th i18n:translate="">Unsubscribed count since send</th>
-              <th i18n:translate="">Default subject</th>
               <th i18n:translate="">Default from email</th>
+              <th i18n:translate="">Default subject</th>
+              <th i18n:translate="">Default language</th>
               <th i18n:translate="">Unsubscribed count</th>
+              <th i18n:translate="">Unsubscribed count since send</th>
               <th i18n:translate="">Cleaned cound</th>
+              <th i18n:translate="">Cleaned count since send</th>
               <th i18n:translate="">Date created</th>
               <th i18n:translate="">List rating</th>
-              <th i18n:translate="">Cleaned count since send</th>
             </tr>
           </thead>
           <tbody tal:repeat="list lists">
             <tr>
-              <td tal:content="list/id"></td>
-              <td tal:content="list/web_id"></td>
-              <td tal:content="list/name"></td>
-              <td tal:content="list/stats/member_count"></td>
-              <td tal:content="list/email_type_option"></td>
-              <td tal:content="list/stats/member_count_since_send"></td>
-              <td tal:content="list/default_language"></td>
-              <td tal:content="list/default_from_name"></td>
-              <td tal:content="list/stats/unsubscribe_count_since_send"></td>
-              <td tal:content="list/default_subject"></td>
-              <td tal:content="list/default_from_email"></td>
-              <td tal:content="list/stats/unsubscribe_count"></td>
-              <td tal:content="list/stats/cleaned_count"></td>
-              <td tal:content="list/date_created"></td>
-              <td tal:content="list/list_rating"></td>
-              <td tal:content="list/stats/cleaned_count_since_send"></td>
+              <td tal:content="list/id|empty"></td>
+              <td tal:content="list/name|empty"></td>
+              <td tal:content="list/stats/member_count|empty"></td>
+              <td tal:content="list/stats/member_count_since_send|empty"></td>
+              <td tal:content="list/campaign_defaults/from_name|empty"></td>
+              <td tal:content="list/campaign_defaults/from_email|empty"></td>
+              <td tal:content="list/campaign_defaults/subject|empty"></td>
+              <td tal:content="list/campaign_defaults/language|empty"></td>
+              <td tal:content="list/stats/unsubscribe_count|empty"></td>
+              <td tal:content="list/stats/unsubscribe_count_since_send|empty"></td>
+              <td tal:content="list/stats/cleaned_count|empty"></td>
+              <td tal:content="list/stats/cleaned_count_since_send|empty"></td>
+              <td tal:content="list/date_created|empty"></td>
+              <td tal:content="list/list_rating|empty"></td>
             </tr>
           </tbody>
         </table>

--- a/collective/mailchimp/browser/controlpanel.pt
+++ b/collective/mailchimp/browser/controlpanel.pt
@@ -8,7 +8,7 @@
 
 <body>
 
-  <div id="content" 
+  <div id="content"
      metal:fill-slot="prefs_configlet_content">
 
     <div metal:use-macro="context/global_statusmessage/macros/portal_message">
@@ -24,7 +24,7 @@
 
     <h1 class="documentFirstHeading" tal:content="view/label">View Title</h1>
 
-    <div id="layout-contents" 
+    <div id="layout-contents"
          class="enableUnloadProtection enableAutoFocus enableFormTabbing enableUnlockProtection"
          tal:define="account view/mailchimp_account|nothing;
                      empty string:-">
@@ -135,7 +135,10 @@
     <script type="text/javascript">
 // Disable inline validation.  It may change the cache based on a new
 // api key that the user has not yet saved.
+// Plone 4:
 $('.z3cformInlineValidation').removeClass('z3cformInlineValidation');
+// Plone 5
+$('.pat-inlinevalidation').removeClass('pat-inlinevalidation');
     </script>
 
   </div>

--- a/collective/mailchimp/browser/controlpanel.py
+++ b/collective/mailchimp/browser/controlpanel.py
@@ -6,7 +6,7 @@ from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from ..exceptions import (
     PostRequestError,
     MailChimpException
-    )
+)
 
 from plone.app.registry.browser import controlpanel
 from plone.protect.interfaces import IDisableCSRFProtection

--- a/collective/mailchimp/browser/controlpanel.py
+++ b/collective/mailchimp/browser/controlpanel.py
@@ -9,7 +9,11 @@ from ..exceptions import (
 )
 
 from plone.app.registry.browser import controlpanel
-from plone.protect.interfaces import IDisableCSRFProtection
+try:
+    from plone.protect.interfaces import IDisableCSRFProtection
+except ImportError:
+    # BBB for old plone.protect, default until at least Plone 4.3.7.
+    IDisableCSRFProtection = None
 from zope.interface import alsoProvides
 
 from collective.mailchimp.interfaces import IMailchimpSettings
@@ -43,7 +47,8 @@ class MailchimpSettingsControlPanel(controlpanel.ControlPanelFormWrapper):
     index = ViewPageTemplateFile('controlpanel.pt')
 
     def mailchimp_account(self):
-        alsoProvides(self.request, IDisableCSRFProtection)
+        if IDisableCSRFProtection is not None:
+            alsoProvides(self.request, IDisableCSRFProtection)
         mailchimp = getUtility(IMailchimpLocator)
         try:
             return mailchimp.account()
@@ -58,7 +63,8 @@ class MailchimpSettingsControlPanel(controlpanel.ControlPanelFormWrapper):
             )
 
     def available_lists(self):
-        alsoProvides(self.request, IDisableCSRFProtection)
+        if IDisableCSRFProtection is not None:
+            alsoProvides(self.request, IDisableCSRFProtection)
         mailchimp = getUtility(IMailchimpLocator)
         try:
             return mailchimp.lists()

--- a/collective/mailchimp/browser/controlpanel.py
+++ b/collective/mailchimp/browser/controlpanel.py
@@ -3,10 +3,14 @@ from z3c.form.interfaces import WidgetActionExecutionError
 from zope.component import getUtility
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 
-from postmonkey import MailChimpException
-from postmonkey.exceptions import PostRequestError
+from ..exceptions import (
+    PostRequestError,
+    MailChimpException
+    )
 
 from plone.app.registry.browser import controlpanel
+from plone.protect.interfaces import IDisableCSRFProtection
+from zope.interface import alsoProvides
 
 from collective.mailchimp.interfaces import IMailchimpSettings
 from collective.mailchimp.interfaces import IMailchimpLocator
@@ -39,6 +43,7 @@ class MailchimpSettingsControlPanel(controlpanel.ControlPanelFormWrapper):
     index = ViewPageTemplateFile('controlpanel.pt')
 
     def mailchimp_account(self):
+        alsoProvides(self.request, IDisableCSRFProtection)
         mailchimp = getUtility(IMailchimpLocator)
         try:
             return mailchimp.account()
@@ -53,6 +58,7 @@ class MailchimpSettingsControlPanel(controlpanel.ControlPanelFormWrapper):
             )
 
     def available_lists(self):
+        alsoProvides(self.request, IDisableCSRFProtection)
         mailchimp = getUtility(IMailchimpLocator)
         try:
             return mailchimp.lists()

--- a/collective/mailchimp/browser/newsletter.py
+++ b/collective/mailchimp/browser/newsletter.py
@@ -115,7 +115,7 @@ class NewsletterSubscriberForm(extensible.ExtensibleForm, form.Form):
                     email_type=email_type,
                 )
             except MailChimpException, error:
-                if error.code == 214:
+                if error.code == 400:
                     error_msg = _(
                         u"mailchimp_error_msg_already_subscribed",
                         default=u"Could not subscribe to newsletter. "
@@ -157,11 +157,17 @@ class NewsletterSubscriberForm(extensible.ExtensibleForm, form.Form):
                     raise ActionExecutionError(
                         Invalid(translated_error_msg)
                     )
-
-            IStatusMessage(self.context.REQUEST).addStatusMessage(_(
+            registry = getUtility(IRegistry)
+            mailchimp_settings = registry.forInterface(IMailchimpSettings)
+            if mailchimp_settings.double_optin:
+                message = _(
                 u"We have to confirm your email address. In order to " +
                 u"finish the newsletter subscription, click on the link " +
-                u"inside the email we just send you."),
+                u"inside the email we just send you.")
+            else:
+                message = _(
+                u"You have been subscribed to our newsletter succesfully.")
+            IStatusMessage(self.context.REQUEST).addStatusMessage(message,
                 type="info"
             )
             portal = getSite()

--- a/collective/mailchimp/browser/newsletter.py
+++ b/collective/mailchimp/browser/newsletter.py
@@ -157,6 +157,7 @@ class NewsletterSubscriberForm(extensible.ExtensibleForm, form.Form):
                     raise ActionExecutionError(
                         Invalid(translated_error_msg)
                     )
+
             IStatusMessage(self.context.REQUEST).addStatusMessage(_(
                 u"We have to confirm your email address. In order to " +
                 u"finish the newsletter subscription, click on the link " +

--- a/collective/mailchimp/browser/newsletter.py
+++ b/collective/mailchimp/browser/newsletter.py
@@ -76,7 +76,7 @@ class NewsletterSubscriberForm(extensible.ExtensibleForm, form.Form):
                     .items[group_index]['checked'] = True
 
     @button.buttonAndHandler(_(u"subscribe_to_newsletter_button",
-                             default=u"Subscribe"),
+                               default=u"Subscribe"),
                              name='subscribe')
     def handleApply(self, action):
         data, errors = self.extractData()
@@ -90,7 +90,8 @@ class NewsletterSubscriberForm(extensible.ExtensibleForm, form.Form):
                 list_id = mailchimp.default_list_id()
 
             # Groupings
-            if 'interest_groups' in data and data['interest_groups'] is not None:
+            if ('interest_groups' in data and
+                    data['interest_groups'] is not None):
                 interest_grouping = mailchimp.groups(list_id=list_id)
                 if interest_grouping and data['interest_groups']:
                     data['groupings'] = [
@@ -108,7 +109,7 @@ class NewsletterSubscriberForm(extensible.ExtensibleForm, form.Form):
                 email_type = 'HTML'
             # Subscribe to MailChimp list
             try:
-                response = mailchimp.subscribe(
+                mailchimp.subscribe(
                     list_id=list_id,
                     email_address=data['email'],
                     email_type=email_type,
@@ -160,15 +161,15 @@ class NewsletterSubscriberForm(extensible.ExtensibleForm, form.Form):
             mailchimp_settings = registry.forInterface(IMailchimpSettings)
             if mailchimp_settings.double_optin:
                 message = _(
-                u"We have to confirm your email address. In order to " +
-                u"finish the newsletter subscription, click on the link " +
-                u"inside the email we just send you.")
+                    u"We have to confirm your email address. In order to " +
+                    u"finish the newsletter subscription, click on the link " +
+                    u"inside the email we just send you.")
             else:
                 message = _(
-                u"You have been subscribed to our newsletter succesfully.")
+                    u"You have been subscribed to our newsletter succesfully.")
             IStatusMessage(self.context.REQUEST).addStatusMessage(message,
-                type="info"
-            )
+                                                                  type="info"
+                                                                  )
             portal = getSite()
             self.request.response.redirect(portal.absolute_url())
 

--- a/collective/mailchimp/browser/newsletter.py
+++ b/collective/mailchimp/browser/newsletter.py
@@ -83,16 +83,15 @@ class NewsletterSubscriberForm(extensible.ExtensibleForm, form.Form):
         data, errors = self.extractData()
         if 'email' in data:
             mailchimp = getUtility(IMailchimpLocator)
-
             # Retrieve list_id either from a hidden field in the form or fetch
             # the first list from mailchimp.
-            if 'list_id' in data:
+            if 'list_id' in data and data['list_id'] is not None:
                 list_id = data['list_id']
             else:
                 list_id = mailchimp.default_list_id()
 
             # Groupings
-            if 'interest_groups' in data:
+            if 'interest_groups' in data and data['interest_groups'] is not None:
                 interest_grouping = mailchimp.groups(list_id=list_id)
                 if interest_grouping and data['interest_groups']:
                     data['groupings'] = [
@@ -107,13 +106,12 @@ class NewsletterSubscriberForm(extensible.ExtensibleForm, form.Form):
             if 'email_type' in data:
                 email_type = data['email_type']
             else:
-                email_type = None
+                email_type = 'HTML'
             # Subscribe to MailChimp list
             try:
-                mailchimp.subscribe(
+                response = mailchimp.subscribe(
                     list_id=list_id,
                     email_address=data['email'],
-                    merge_vars=data,
                     email_type=email_type,
                 )
             except MailChimpException, error:
@@ -159,7 +157,6 @@ class NewsletterSubscriberForm(extensible.ExtensibleForm, form.Form):
                     raise ActionExecutionError(
                         Invalid(translated_error_msg)
                     )
-
             IStatusMessage(self.context.REQUEST).addStatusMessage(_(
                 u"We have to confirm your email address. In order to " +
                 u"finish the newsletter subscription, click on the link " +

--- a/collective/mailchimp/browser/newsletter.py
+++ b/collective/mailchimp/browser/newsletter.py
@@ -80,98 +80,90 @@ class NewsletterSubscriberForm(extensible.ExtensibleForm, form.Form):
                              name='subscribe')
     def handleApply(self, action):
         data, errors = self.extractData()
-        if 'email' in data:
-            mailchimp = getUtility(IMailchimpLocator)
-            # Retrieve list_id either from a hidden field in the form or fetch
-            # the first list from mailchimp.
-            if 'list_id' in data and data['list_id'] is not None:
-                list_id = data['list_id']
-            else:
-                list_id = mailchimp.default_list_id()
+        if 'email' not in data:
+            return
+        mailchimp = getUtility(IMailchimpLocator)
+        # Retrieve list_id either from a hidden field in the form or fetch
+        # the first list from mailchimp.
+        if 'list_id' in data and data['list_id'] is not None:
+            list_id = data['list_id']
+        else:
+            list_id = mailchimp.default_list_id()
 
-            # Groupings
-            if ('interest_groups' in data and
-                    data['interest_groups'] is not None):
-                interest_grouping = mailchimp.groups(list_id=list_id)
-                if interest_grouping and data['interest_groups']:
-                    data['groupings'] = [
-                        {
-                            'id': interest_grouping['id'],
-                            'groups': ",".join(data['interest_groups']),
-                        }
-                    ]
+        # Groupings
+        if 'interest_groups' in data and data['interest_groups'] is not None:
+            interest_grouping = mailchimp.groups(list_id=list_id)
+            if interest_grouping and data['interest_groups']:
+                data['groupings'] = [
+                    {
+                        'id': interest_grouping['id'],
+                        'groups': ",".join(data['interest_groups']),
+                    }
+                ]
 
-            # Use email_type if one is provided by the form, if not choose the
-            # default email type from the control panel settings.
-            if 'email_type' in data:
-                email_type = data['email_type']
-            else:
-                email_type = 'HTML'
-            # Subscribe to MailChimp list
-            try:
-                mailchimp.subscribe(
-                    list_id=list_id,
-                    email_address=data['email'],
-                    email_type=email_type,
-                )
-            except MailChimpException as error:
-                if error.code == 400:
-                    error_msg = _(
-                        u"mailchimp_error_msg_already_subscribed",
-                        default=u"Could not subscribe to newsletter. "
-                                u"The email '${email}' is already subscribed.",
-                        mapping={
-                            u"email": data['email']
-                        }
-                    )
-                    translated_error_msg = self.context.translate(error_msg)
-                    raise WidgetActionExecutionError(
-                        'email',
-                        Invalid(translated_error_msg)
-                    )
-                elif error.code == 220:
-                    error_msg = _(
-                        u"mailchimp_error_msg_banned",
-                        default=u"Could not subscribe to newsletter. "
-                                u"The email '${email}' has been banned.",
-                        mapping={
-                            u"email": data['email']
-                        }
-                    )
-                    translated_error_msg = self.context.translate(error_msg)
-                    raise WidgetActionExecutionError(
-                        'email',
-                        Invalid(translated_error_msg)
-                    )
-                else:
-                    error_msg = _(
-                        u"mailchimp_error_msg",
-                        default=u"Could not subscribe to newsletter. "
-                                u"Please contact the site administrator: "
-                                u"'${error}'",
-                        mapping={
-                            u"error": error
-                        }
-                    )
-                    translated_error_msg = self.context.translate(error_msg)
-                    raise ActionExecutionError(
-                        Invalid(translated_error_msg)
-                    )
-            registry = getUtility(IRegistry)
-            mailchimp_settings = registry.forInterface(IMailchimpSettings)
-            if mailchimp_settings.double_optin:
-                message = _(
-                    u"We have to confirm your email address. In order to " +
-                    u"finish the newsletter subscription, click on the link " +
-                    u"inside the email we just send you.")
-            else:
-                message = _(
-                    u"You have been subscribed to our newsletter succesfully.")
-            IStatusMessage(self.context.REQUEST).addStatusMessage(message,
-                                                                  type="info"
-                                                                  )
-            portal = getSite()
-            self.request.response.redirect(portal.absolute_url())
+        # Use email_type if one is provided by the form, if not choose the
+        # default email type from the control panel settings.
+        if 'email_type' in data:
+            email_type = data['email_type']
+        else:
+            email_type = 'HTML'
+        # Subscribe to MailChimp list
+        try:
+            mailchimp.subscribe(
+                list_id=list_id,
+                email_address=data['email'],
+                email_type=email_type,
+            )
+        except MailChimpException as error:
+            return self.handle_error(error, data)
+        registry = getUtility(IRegistry)
+        mailchimp_settings = registry.forInterface(IMailchimpSettings)
+        if mailchimp_settings.double_optin:
+            message = _(
+                u"We have to confirm your email address. In order to " +
+                u"finish the newsletter subscription, click on the link " +
+                u"inside the email we just send you.")
+        else:
+            message = _(
+                u"You have been subscribed to our newsletter succesfully.")
+        IStatusMessage(self.context.REQUEST).addStatusMessage(
+            message, type="info")
+        portal = getSite()
+        self.request.response.redirect(portal.absolute_url())
 
+    def handle_error(self, error, data):
+        if error.code == 400:
+            error_msg = _(
+                u"mailchimp_error_msg_already_subscribed",
+                default=u"Could not subscribe to newsletter. "
+                        u"The email '${email}' is already subscribed.",
+                mapping={u"email": data['email']})
+            translated_error_msg = self.context.translate(error_msg)
+            raise WidgetActionExecutionError(
+                'email',
+                Invalid(translated_error_msg)
+            )
+        elif error.code == 220:
+            error_msg = _(
+                u"mailchimp_error_msg_banned",
+                default=u"Could not subscribe to newsletter. "
+                        u"The email '${email}' has been banned.",
+                mapping={u"email": data['email']})
+            translated_error_msg = self.context.translate(error_msg)
+            raise WidgetActionExecutionError(
+                'email',
+                Invalid(translated_error_msg)
+            )
+        else:
+            error_msg = _(
+                u"mailchimp_error_msg",
+                default=u"Could not subscribe to newsletter. "
+                        u"Please contact the site administrator: "
+                        u"'${error}'",
+                mapping={u"error": error})
+            translated_error_msg = self.context.translate(error_msg)
+            raise ActionExecutionError(
+                Invalid(translated_error_msg)
+            )
 
 NewsletterView = wrap_form(NewsletterSubscriberForm)

--- a/collective/mailchimp/browser/newsletter.py
+++ b/collective/mailchimp/browser/newsletter.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 from Products.statusmessages.interfaces import IStatusMessage
 
-from postmonkey import MailChimpException
-
 from zope.interface import Invalid
 from zope.interface import implements
 from zope.annotation.interfaces import IAttributeAnnotatable
@@ -21,6 +19,7 @@ from plone.z3cform.layout import wrap_form
 from plone.z3cform.fieldsets import extensible
 
 from collective.mailchimp import _
+from collective.mailchimp.exceptions import MailChimpException
 from collective.mailchimp.interfaces import IMailchimpLocator
 from collective.mailchimp.interfaces import IMailchimpSettings
 from collective.mailchimp.interfaces import INewsletterSubscribe
@@ -114,7 +113,7 @@ class NewsletterSubscriberForm(extensible.ExtensibleForm, form.Form):
                     email_address=data['email'],
                     email_type=email_type,
                 )
-            except MailChimpException, error:
+            except MailChimpException as error:
                 if error.code == 400:
                     error_msg = _(
                         u"mailchimp_error_msg_already_subscribed",

--- a/collective/mailchimp/browser/portlet.py
+++ b/collective/mailchimp/browser/portlet.py
@@ -40,8 +40,8 @@ class IMailChimpPortlet(IPortletDataProvider):
         min_length=1,
         value_type=schema.Choice(
             source='collective.mailchimp.vocabularies.AvailableLists'
-            )
         )
+    )
 
 
 class Assignment(base.Assignment):

--- a/collective/mailchimp/exceptions.py
+++ b/collective/mailchimp/exceptions.py
@@ -1,0 +1,48 @@
+class SerializationError(Exception):
+    """ Raised if a method call contains parameters that cannot be serialized to
+    JSON. The object that caused the error is made available via the ``obj``
+    attribute.
+    """
+    def __init__(self, obj):
+        self.obj = obj
+
+    def __str__(self):
+        return '%s could not be serialized to json' % self.obj
+
+
+class DeserializationError(Exception):
+    """ Raised if MailChimp responds with anything other than valid JSON.
+    `PostMonkey` uses MailChimp's JSON API exclusively so it is unlikely
+    that this will be raised. The response that caused the error is
+    made available via the ``obj`` attribute.
+    """
+    def __init__(self, obj):
+        self.obj = obj
+
+    def __str__(self):
+        return '%s could not be deserialized' % self.obj
+
+
+class PostRequestError(Exception):
+    """ If any exception is made during the POST request to MailChimp's server,
+    `PostRequestError` will be raised. It wraps the underlying exception
+    object and makes it available via the ``exc`` attribute.
+    """
+    def __init__(self, exc):
+        self.exc = exc
+
+    def __str__(self):
+        return 'Caught exc "%s" with error "%s"' % (type(self.exc), self.exc)
+
+
+class MailChimpException(Exception):
+    """ If MailChimp returns an exception code as part of their response,
+    this exception will be raised. Contains the unmodified ``code`` (int) and
+    ``error`` (unicode) attributes returned by MailChimp.
+    """
+    def __init__(self, code, error):
+        self.code = code
+        self.error = error
+
+    def __str__(self):
+        return 'MailChimp error code %s: "%s"' % (self.code, self.error)

--- a/collective/mailchimp/exceptions.py
+++ b/collective/mailchimp/exceptions.py
@@ -47,9 +47,11 @@ class MailChimpException(Exception):
     ``error`` (unicode) attributes returned by MailChimp.
     """
 
-    def __init__(self, code, error):
+    def __init__(self, code, detail, errors=''):
         self.code = code
-        self.error = error
+        self.detail = detail
+        self.errors = errors
 
     def __str__(self):
-        return 'MailChimp error code %s: "%s"' % (self.code, self.error)
+        return 'MailChimp error code {0}: "{1}"\n{2}'.format(
+            self.code, self.detail, self.errors)

--- a/collective/mailchimp/exceptions.py
+++ b/collective/mailchimp/exceptions.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 class SerializationError(Exception):
     """ Raised if a method call contains parameters that cannot be serialized to
     JSON. The object that caused the error is made available via the ``obj``
@@ -12,7 +14,7 @@ class SerializationError(Exception):
 
 class DeserializationError(Exception):
     """ Raised if MailChimp responds with anything other than valid JSON.
-    `PostMonkey` uses MailChimp's JSON API exclusively so it is unlikely
+    We use MailChimp's JSON API exclusively so it is unlikely
     that this will be raised. The response that caused the error is
     made available via the ``obj`` attribute.
     """

--- a/collective/mailchimp/exceptions.py
+++ b/collective/mailchimp/exceptions.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
 
+
 class SerializationError(Exception):
     """ Raised if a method call contains parameters that cannot be serialized to
     JSON. The object that caused the error is made available via the ``obj``
     attribute.
     """
+
     def __init__(self, obj):
         self.obj = obj
 
@@ -18,6 +20,7 @@ class DeserializationError(Exception):
     that this will be raised. The response that caused the error is
     made available via the ``obj`` attribute.
     """
+
     def __init__(self, obj):
         self.obj = obj
 
@@ -30,6 +33,7 @@ class PostRequestError(Exception):
     `PostRequestError` will be raised. It wraps the underlying exception
     object and makes it available via the ``exc`` attribute.
     """
+
     def __init__(self, exc):
         self.exc = exc
 
@@ -42,6 +46,7 @@ class MailChimpException(Exception):
     this exception will be raised. Contains the unmodified ``code`` (int) and
     ``error`` (unicode) attributes returned by MailChimp.
     """
+
     def __init__(self, code, error):
         self.code = code
         self.error = error

--- a/collective/mailchimp/interfaces.py
+++ b/collective/mailchimp/interfaces.py
@@ -131,7 +131,7 @@ class IMailchimpSettings(Interface):
             default=u"Email type preference for the email (html, text, or "
                     u"mobile defaults to html)"),
         vocabulary="collective.mailchimp.vocabularies.EmailType",
-        default="text",
+        default="html",
         required=True,
     )
 

--- a/collective/mailchimp/interfaces.py
+++ b/collective/mailchimp/interfaces.py
@@ -215,4 +215,3 @@ class IMailchimpSettings(Interface):
             raise Invalid(
                 u"Your MailChimp API key is not valid. Please go " +
                 u"to mailchimp.com and check your API key.")
-    

--- a/collective/mailchimp/interfaces.py
+++ b/collective/mailchimp/interfaces.py
@@ -1,6 +1,7 @@
 import re
 
 from postmonkey import PostMonkey
+from postmonkey.exceptions import MailChimpException
 
 from zope import schema
 from zope.interface import Interface
@@ -215,7 +216,7 @@ class IMailchimpSettings(Interface):
         mailchimp = PostMonkey(data.api_key)
         try:
             return mailchimp.ping()
-        except:
+        except MailChimpException:
             raise Invalid(
                 u"Your MailChimp API key is not valid. Please go " +
                 u"to mailchimp.com and check your API key.")

--- a/collective/mailchimp/interfaces.py
+++ b/collective/mailchimp/interfaces.py
@@ -1,9 +1,6 @@
 import re
 
-from . exceptions import MailChimpException
-
 from zope import schema
-from zope.component import getUtility
 from zope.interface import Interface
 from zope.interface import invariant
 from zope.interface import Invalid
@@ -213,10 +210,9 @@ class IMailchimpSettings(Interface):
     def valid_api_key(data):
         if len(data.api_key) == 0:
             return
-        mailchimp = getUtility(IMailchimpLocator)
-        try:
-            return mailchimp.ping()
-        except MailChimpException:
+        parts = data.api_key.split('-')
+        if len(parts) != 2:
             raise Invalid(
                 u"Your MailChimp API key is not valid. Please go " +
                 u"to mailchimp.com and check your API key.")
+    

--- a/collective/mailchimp/interfaces.py
+++ b/collective/mailchimp/interfaces.py
@@ -1,9 +1,9 @@
 import re
 
-from postmonkey import PostMonkey
-from postmonkey.exceptions import MailChimpException
+from . exceptions import MailChimpException
 
 from zope import schema
+from zope.component import getUtility
 from zope.interface import Interface
 from zope.interface import invariant
 from zope.interface import Invalid
@@ -81,7 +81,7 @@ class IMailchimpLocator(Interface):
     """Mailchimp API
     """
 
-    def connect():
+    def initialize():
         """Do a postmonkey with the API so your connected to mailchimp API"""
 
     def lists():
@@ -213,7 +213,7 @@ class IMailchimpSettings(Interface):
     def valid_api_key(data):
         if len(data.api_key) == 0:
             return
-        mailchimp = PostMonkey(data.api_key)
+        mailchimp = getUtility(IMailchimpLocator)
         try:
             return mailchimp.ping()
         except MailChimpException:

--- a/collective/mailchimp/locales/nl/LC_MESSAGES/collective.mailchimp.po
+++ b/collective/mailchimp/locales/nl/LC_MESSAGES/collective.mailchimp.po
@@ -312,7 +312,7 @@ msgstr "Laat gebruikers hun e-mail type voorkeur kiezen in het formulier voor in
 
 #: collective/mailchimp/interfaces.py:56
 msgid "help_interest_groups"
-msgstr "help_interest_groups"
+msgstr ""
 
 #. Default: "Flag to determine whether we replace the interest groups with the groups provided or we add the providedgroups to the member's interest groups (optional, defaults to true)"
 #: collective/mailchimp/interfaces.py:186
@@ -375,4 +375,3 @@ msgstr "Inschrijven"
 #: collective/mailchimp/interfaces.py:174
 msgid "update_existing"
 msgstr "update_existing"
-

--- a/collective/mailchimp/locator.py
+++ b/collective/mailchimp/locator.py
@@ -55,8 +55,6 @@ class MailchimpLocator(object):
             return []
         except PostRequestError:
             return []
-        except:
-            raise
 
     def default_list_id(self):
         self.connect()

--- a/collective/mailchimp/locator.py
+++ b/collective/mailchimp/locator.py
@@ -36,6 +36,7 @@ class MailchimpLocator(object):
         """ Use settings if provided """
         self.registry = None
         self.settings = None
+        self.api_root = None
         if settings:
             self.settings = settings
 
@@ -46,6 +47,8 @@ class MailchimpLocator(object):
         if self.settings is None:
             self.settings = self.registry.forInterface(IMailchimpSettings)
         self.apikey = self.settings.api_key
+        if not self.apikey:
+            return
         parts = self.apikey.split('-')
         self.shard = parts[1]
         self.api_root = "https://" + self.shard + ".api.mailchimp.com/3.0/"
@@ -92,6 +95,8 @@ class MailchimpLocator(object):
     def api_request(self, endpoint='', request_type='get', **kwargs):
         """ construct the request and do a get/post.
         """
+        if not self.api_root:
+            return []
         headers = {'content-type': 'application/json'}
         url = urlparse.urljoin(self.api_root, endpoint)
         # we provide a json structure with the parameters.

--- a/collective/mailchimp/locator.py
+++ b/collective/mailchimp/locator.py
@@ -89,8 +89,8 @@ class MailchimpLocator(object):
         if not isinstance(response, dict):
             return
         # case: response is a dict and may be an error response
-        elif 'code' in response and 'error' in response:
-            raise MailChimpException(response['code'], response['error'])
+        elif 'status' in response and 'detail' in response:
+            raise MailChimpException(response['status'], response['detail'])
 
     def api_request(self, endpoint='', request_type='get', **kwargs):
         """ construct the request and do a get/post.
@@ -170,19 +170,22 @@ class MailchimpLocator(object):
     def subscribe(self, list_id, email_address, email_type):
         """ API call to subscribe a member to a list. """
         self.initialize()
+        opt_in_status = 'subscribed'
+        if self.settings.double_optin:
+            opt_in_status = 'pending'
         if not email_type:
             email_type = self.settings.email_type
         try:
             endpoint = 'lists/' + list_id + '/members'
             response = self.api_request(endpoint,
                             request_type='post',
-                            status='subscribed',
+                            status=opt_in_status,
                             email_address=email_address,
                             email_type=email_type)
-        except Exception, e:
-            raise PostRequestError(e)
         except MailChimpException:
             raise
+        except Exception, e:
+            raise PostRequestError(e)
         logger.info("Subscribed %s to list with id: %s." % \
             (email_address, list_id))
         logger.debug("Subscribed %s to list with id: %s.\n\n %s" % \

--- a/collective/mailchimp/locator.py
+++ b/collective/mailchimp/locator.py
@@ -17,7 +17,7 @@ from . exceptions import (
     DeserializationError,
     PostRequestError,
     MailChimpException,
-    )
+)
 
 _marker = object()
 logger = logging.getLogger('collective.mailchimp')
@@ -103,9 +103,11 @@ class MailchimpLocator(object):
         payload = json.dumps(kwargs)
         try:
             if request_type.lower() == 'post':
-                resp = requests.post(url, auth=('apikey', self.apikey), data=payload, headers=headers)
+                resp = requests.post(url, auth=(
+                    'apikey', self.apikey), data=payload, headers=headers)
             else:
-                resp = requests.get(url, auth=('apikey', self.apikey), data=payload, headers=headers)
+                resp = requests.get(url, auth=(
+                    'apikey', self.apikey), data=payload, headers=headers)
         except Exception, e:
             raise PostRequestError(e)
         decoded = self._deserialize_response(resp.text)
@@ -178,18 +180,18 @@ class MailchimpLocator(object):
         try:
             endpoint = 'lists/' + list_id + '/members'
             response = self.api_request(endpoint,
-                            request_type='post',
-                            status=opt_in_status,
-                            email_address=email_address,
-                            email_type=email_type)
+                                        request_type='post',
+                                        status=opt_in_status,
+                                        email_address=email_address,
+                                        email_type=email_type)
         except MailChimpException:
             raise
         except Exception, e:
             raise PostRequestError(e)
-        logger.info("Subscribed %s to list with id: %s." % \
-            (email_address, list_id))
-        logger.debug("Subscribed %s to list with id: %s.\n\n %s" % \
-            (email_address, list_id, response))
+        logger.info("Subscribed %s to list with id: %s." %
+                    (email_address, list_id))
+        logger.debug("Subscribed %s to list with id: %s.\n\n %s" %
+                     (email_address, list_id, response))
         return response
 
     def account(self):

--- a/collective/mailchimp/testing.py
+++ b/collective/mailchimp/testing.py
@@ -78,6 +78,10 @@ class MockRequests(object):
         elif endpoint == 'lists':
             path = os.path.join(
                 TEST_DATA_DIR, 'lists.json')
+        elif re.compile('lists/.*/interest-categories/.*/interests').match(
+                endpoint):
+            path = os.path.join(
+                TEST_DATA_DIR, 'interests.json')
         elif re.compile('lists/.*/interest-categories').match(endpoint):
             path = os.path.join(
                 TEST_DATA_DIR, 'lists_interest_categories.json')

--- a/collective/mailchimp/testing.py
+++ b/collective/mailchimp/testing.py
@@ -1,138 +1,50 @@
-from collective.mailchimp.interfaces import IMailchimpSettings
-from zope.component import getUtility
-from plone.registry.interfaces import IRegistry
-from plone.app.testing import PloneSandboxLayer
+# -*- coding: utf-8 -*-
+from plone.app.contenttypes.testing import PLONE_APP_CONTENTTYPES_FIXTURE
+from plone.app.robotframework.testing import REMOTE_LIBRARY_BUNDLE_FIXTURE
 from plone.app.testing import applyProfile
-from plone.app.testing import PLONE_FIXTURE
-from plone.app.testing import IntegrationTesting
 from plone.app.testing import FunctionalTesting
-
+from plone.app.testing import IntegrationTesting
+from plone.app.testing import PloneSandboxLayer
+from plone.registry.interfaces import IRegistry
+from plone.testing import z2
 from zope.configuration import xmlconfig
+from zope.component import getUtility
+
+from collective.mailchimp.interfaces import IMailchimpSettings
+import collective.mailchimp
 
 
 class CollectiveMailchimp(PloneSandboxLayer):
 
-    defaultBases = (PLONE_FIXTURE,)
+    defaultBases = (PLONE_APP_CONTENTTYPES_FIXTURE,)
 
     def setUpZope(self, app, configurationContext):
-        from mocker import Mocker
-        from mocker import ANY
-        from mocker import KWARGS
-        mocker = Mocker()
-        postmonkey = mocker.replace("postmonkey")
-        mailchimp = postmonkey.PostMonkey(ANY)
-        mocker.count(0, 1000)
-        # Lists
-        mailchimp.lists()
-        mocker.count(0, 1000)
-        mocker.result({
-            u'total': 2,
-            u'data': [
-                {
-                    u'id': u'f6257645gs',
-                    u'web_id': 625,
-                    u'name': u'ACME Newsletter',
-                    u'default_from_name': u'info@acme.com',
-                },
-                {
-                    u'id': u'f6267645gs',
-                    u'web_id': 626,
-                    u'name': u'ACME Newsletter 2',
-                    u'default_from_name': u'info@acme.com',
-                },
-            ]
-        })
-        # List Interest Groupings
-        mailchimp.listInterestGroupings(KWARGS)
-        mocker.count(0, 1000)
-        mocker.result([
-            {
-                u'groups': [
-                    {
-                        u'bit': u'1',
-                        u'display_order': u'1',
-                        u'name': u'Interest Group 1',
-                        u'subscribers': 0
-                    },
-                    {
-                        u'bit': u'2',
-                        u'display_order': u'2',
-                        u'name': u'Interest Group 2',
-                        u'subscribers': 0
-                    },
-                    {
-                        u'bit': u'3',
-                        u'display_order': u'3',
-                        u'name': u'Interest Group 3',
-                        u'subscribers': 1
-                    }
-                ]
-            }
-        ])
-
-        # Get account details
-        mailchimp.getAccountDetails()
-        mocker.count(0, 1000)
-        mocker.result({})
-        result = {  # noqa
-            u'total': 1,
-            u'data': [{
-                u'use_awesomebar': True,
-                u'beamer_address': u'NWVmY2ZkYjjNjc=@campaigns.mailchimp.com',
-                u'web_id': 17241,
-                u'name': u'Test Newsletter',
-                u'email_type_option': False,
-                u'modules': [],
-                u'default_language': u'de',
-                u'default_from_name': u'Timo Stollenwerk',
-                u'visibility': u'pub',
-                u'subscribe_url_long':
-                    u'http://johndoe.us4.list-manage1.com/subscribe?u=5e&id=fd',  # noqa
-                u'default_subject': u'Test Newsletter',
-                u'subscribe_url_short': u'http://eepurl.com/h6Rjg',
-                u'default_from_email': u'no-reply@timostollenwerk.net',
-                u'date_created': u'2011-12-27 16:15:03',
-                u'list_rating': 0,
-                u'id': u'f6257645gs',
-                u'stats': {
-                    u'grouping_count': 0,
-                    u'open_rate': None,
-                    u'member_count': 0,
-                    u'click_rate': None,
-                    u'cleaned_count_since_send': 0,
-                    u'member_count_since_send': 0,
-                    u'target_sub_rate': None,
-                    u'group_count': 0,
-                    u'avg_unsub_rate': None,
-                    u'merge_var_count': 2,
-                    u'unsubscribe_count': 0,
-                    u'cleaned_count': 0,
-                    u'avg_sub_rate': None,
-                    u'unsubscribe_count_since_send': 0,
-                    u'campaign_count': 1
-                    }
-                }
-            ]}
-
-        mocker.replay()
-
-        # Load ZCML
-        import collective.mailchimp
-        xmlconfig.file('configure.zcml',
-                       collective.mailchimp,
-                       context=configurationContext)
+        self.loadZCML(package=collective.mailchimp)        
 
     def setUpPloneSite(self, portal):
         applyProfile(portal, 'collective.mailchimp:default')
-
         registry = getUtility(IRegistry)
         mailchimp_settings = registry.forInterface(IMailchimpSettings)
-        mailchimp_settings.api_key = u"abc"
+        mailchimp_settings.api_key = u"abcdefg-us2"
+
 
 COLLECTIVE_MAILCHIMP_FIXTURE = CollectiveMailchimp()
+
 COLLECTIVE_MAILCHIMP_INTEGRATION_TESTING = IntegrationTesting(
     bases=(COLLECTIVE_MAILCHIMP_FIXTURE,),
-    name="CollectiveMailchimp:Integration")
+    name='CollectiveMailchimp:IntegrationTesting'
+)
+
 COLLECTIVE_MAILCHIMP_FUNCTIONAL_TESTING = FunctionalTesting(
     bases=(COLLECTIVE_MAILCHIMP_FIXTURE,),
-    name="CollectiveMailchimp:Functional")
+    name='CollectiveMailchimp:FunctionalTesting'
+)
+
+COLLECTIVE_MAILCHIMP_ACCEPTANCE_TESTING = FunctionalTesting(
+    bases=(
+        COLLECTIVE_MAILCHIMP_FIXTURE,
+        REMOTE_LIBRARY_BUNDLE_FIXTURE,
+        z2.ZSERVER_FIXTURE
+    ),
+    name='CollectiveMailchimp:AcceptanceTesting'
+)

--- a/collective/mailchimp/testing.py
+++ b/collective/mailchimp/testing.py
@@ -1,3 +1,6 @@
+import json
+import os
+import re
 from collective.mailchimp.interfaces import IMailchimpSettings
 from zope.component import getUtility
 from plone.registry.interfaces import IRegistry
@@ -8,6 +11,85 @@ from plone.app.testing import IntegrationTesting
 from plone.app.testing import FunctionalTesting
 
 from zope.configuration import xmlconfig
+from mock import Mock
+from mock import patch
+
+DUMMY_API_KEY = u"abc-us1"
+TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), 'tests', 'data')
+
+
+class MockRequestsException(Exception):
+    """Exception raised in the requests mock.
+
+    This makes it easier to distinguish between exceptions of the
+    original and the patched module.
+    """
+
+
+class MockRequests(object):
+    """Class used as mock replacement for the requests module.
+    """
+
+    @staticmethod
+    def parse_arguments(*args, **kwargs):
+        """Parse the arguments and return whatever we need.
+        """
+        if len(args) != 1:
+            raise MockRequestsException(
+                'Expected 1 argument, got {0}: {1}'.format(
+                    len(args), args))
+        # Check url
+        url = args[0]
+        mailchimp_url = 'api.mailchimp.com/3.0/'
+        if mailchimp_url not in url:
+            raise MockRequestsException('Expected {0} in url {1}'.format(
+                mailchimp_url, url))
+        endpoint = url.split(mailchimp_url)[1]
+        # Check auth
+        auth = kwargs.get('auth')
+        if not auth:
+            raise MockRequestsException('Expected auth in keyword arguments.')
+        expected_auth = ('apikey', DUMMY_API_KEY)
+        if (not isinstance(auth, tuple) or len(auth) != 2 or
+                expected_auth != auth):
+            raise MockRequestsException(
+                'Expected auth {0} in keyword arguments. Got {1}'.format(
+                    expected_auth, auth))
+        data = kwargs.get('data')
+        # Load the data.
+        if not data:
+            raise MockRequestsException('Expected data in keyword arguments.')
+        data = json.loads(data)
+        if data:
+            raise MockRequestsException('TODO: handle data.')
+        return endpoint
+
+    @staticmethod
+    def post(*args, **kwargs):
+        """This is a mock for post and get in the requests module.
+
+        Return a json dictionary based on the end point.
+        """
+        endpoint = MockRequests.parse_arguments(*args, **kwargs)
+        path = ''
+        text = '{}'
+        if not endpoint:
+            path = os.path.join(TEST_DATA_DIR, 'account.json')
+        elif endpoint == 'lists':
+            path = os.path.join(
+                TEST_DATA_DIR, 'lists.json')
+        elif re.compile('lists/.*/interest-categories').match(endpoint):
+            path = os.path.join(
+                TEST_DATA_DIR, 'lists_interest_categories.json')
+        else:
+            print('WARNING, unhandled endpoint in test: {0}'.format(endpoint))
+        if path:
+            with open(path) as datafile:
+                text = datafile.read()
+        # Return mock response with text.
+        return Mock(text=text)
+
+    get = post
 
 
 class CollectiveMailchimp(PloneSandboxLayer):
@@ -15,106 +97,14 @@ class CollectiveMailchimp(PloneSandboxLayer):
     defaultBases = (PLONE_FIXTURE,)
 
     def setUpZope(self, app, configurationContext):
-        from mocker import Mocker
-        from mocker import ANY
-        from mocker import KWARGS
-        mocker = Mocker()
-        postmonkey = mocker.replace("postmonkey")
-        mailchimp = postmonkey.PostMonkey(ANY)
-        mocker.count(0, 1000)
-        # Lists
-        mailchimp.lists()
-        mocker.count(0, 1000)
-        mocker.result({
-            u'total': 2,
-            u'data': [
-                {
-                    u'id': u'f6257645gs',
-                    u'web_id': 625,
-                    u'name': u'ACME Newsletter',
-                    u'default_from_name': u'info@acme.com',
-                },
-                {
-                    u'id': u'f6267645gs',
-                    u'web_id': 626,
-                    u'name': u'ACME Newsletter 2',
-                    u'default_from_name': u'info@acme.com',
-                },
-            ]
-        })
-        # List Interest Groupings
-        mailchimp.listInterestGroupings(KWARGS)
-        mocker.count(0, 1000)
-        mocker.result([
-            {
-                u'groups': [
-                    {
-                        u'bit': u'1',
-                        u'display_order': u'1',
-                        u'name': u'Interest Group 1',
-                        u'subscribers': 0
-                    },
-                    {
-                        u'bit': u'2',
-                        u'display_order': u'2',
-                        u'name': u'Interest Group 2',
-                        u'subscribers': 0
-                    },
-                    {
-                        u'bit': u'3',
-                        u'display_order': u'3',
-                        u'name': u'Interest Group 3',
-                        u'subscribers': 1
-                    }
-                ]
-            }
-        ])
-
-        # Get account details
-        mailchimp.getAccountDetails()
-        mocker.count(0, 1000)
-        mocker.result({})
-        result = {  # noqa
-            u'total': 1,
-            u'data': [{
-                u'use_awesomebar': True,
-                u'beamer_address': u'NWVmY2ZkYjjNjc=@campaigns.mailchimp.com',
-                u'web_id': 17241,
-                u'name': u'Test Newsletter',
-                u'email_type_option': False,
-                u'modules': [],
-                u'default_language': u'de',
-                u'default_from_name': u'Timo Stollenwerk',
-                u'visibility': u'pub',
-                u'subscribe_url_long':
-                    u'http://johndoe.us4.list-manage1.com/subscribe?u=5e&id=fd',  # noqa
-                u'default_subject': u'Test Newsletter',
-                u'subscribe_url_short': u'http://eepurl.com/h6Rjg',
-                u'default_from_email': u'no-reply@timostollenwerk.net',
-                u'date_created': u'2011-12-27 16:15:03',
-                u'list_rating': 0,
-                u'id': u'f6257645gs',
-                u'stats': {
-                    u'grouping_count': 0,
-                    u'open_rate': None,
-                    u'member_count': 0,
-                    u'click_rate': None,
-                    u'cleaned_count_since_send': 0,
-                    u'member_count_since_send': 0,
-                    u'target_sub_rate': None,
-                    u'group_count': 0,
-                    u'avg_unsub_rate': None,
-                    u'merge_var_count': 2,
-                    u'unsubscribe_count': 0,
-                    u'cleaned_count': 0,
-                    u'avg_sub_rate': None,
-                    u'unsubscribe_count_since_send': 0,
-                    u'campaign_count': 1
-                    }
-                }
-            ]}
-
-        mocker.replay()
+        # Create patcher to mock the requests module that is imported in
+        # locator.py only.
+        self.requests_patcher = patch(
+            'collective.mailchimp.locator.requests', new_callable=MockRequests)
+        # It looks like the patcher is started automatically, although the
+        # documentation says you must start it explicitly.  Let's follow the
+        # documentation.  Then we can also nicely stop it in tearDownZope.
+        self.requests_patcher.start()
 
         # Load ZCML
         import collective.mailchimp
@@ -127,7 +117,12 @@ class CollectiveMailchimp(PloneSandboxLayer):
 
         registry = getUtility(IRegistry)
         mailchimp_settings = registry.forInterface(IMailchimpSettings)
-        mailchimp_settings.api_key = u"abc"
+        mailchimp_settings.api_key = DUMMY_API_KEY
+
+    def tearDownZope(self, app):
+        # Undo our requests patch.
+        self.requests_patcher.stop()
+
 
 COLLECTIVE_MAILCHIMP_FIXTURE = CollectiveMailchimp()
 COLLECTIVE_MAILCHIMP_INTEGRATION_TESTING = IntegrationTesting(

--- a/collective/mailchimp/testing.py
+++ b/collective/mailchimp/testing.py
@@ -7,7 +7,6 @@ from plone.app.testing import IntegrationTesting
 from plone.app.testing import PloneSandboxLayer
 from plone.registry.interfaces import IRegistry
 from plone.testing import z2
-from zope.configuration import xmlconfig
 from zope.component import getUtility
 
 from collective.mailchimp.interfaces import IMailchimpSettings
@@ -19,7 +18,7 @@ class CollectiveMailchimp(PloneSandboxLayer):
     defaultBases = (PLONE_APP_CONTENTTYPES_FIXTURE,)
 
     def setUpZope(self, app, configurationContext):
-        self.loadZCML(package=collective.mailchimp)        
+        self.loadZCML(package=collective.mailchimp)
 
     def setUpPloneSite(self, portal):
         applyProfile(portal, 'collective.mailchimp:default')

--- a/collective/mailchimp/testing.py
+++ b/collective/mailchimp/testing.py
@@ -1,49 +1,138 @@
-# -*- coding: utf-8 -*-
-from plone.app.contenttypes.testing import PLONE_APP_CONTENTTYPES_FIXTURE
-from plone.app.robotframework.testing import REMOTE_LIBRARY_BUNDLE_FIXTURE
-from plone.app.testing import applyProfile
-from plone.app.testing import FunctionalTesting
-from plone.app.testing import IntegrationTesting
-from plone.app.testing import PloneSandboxLayer
-from plone.registry.interfaces import IRegistry
-from plone.testing import z2
-from zope.component import getUtility
-
 from collective.mailchimp.interfaces import IMailchimpSettings
-import collective.mailchimp
+from zope.component import getUtility
+from plone.registry.interfaces import IRegistry
+from plone.app.testing import PloneSandboxLayer
+from plone.app.testing import applyProfile
+from plone.app.testing import PLONE_FIXTURE
+from plone.app.testing import IntegrationTesting
+from plone.app.testing import FunctionalTesting
+
+from zope.configuration import xmlconfig
 
 
 class CollectiveMailchimp(PloneSandboxLayer):
 
-    defaultBases = (PLONE_APP_CONTENTTYPES_FIXTURE,)
+    defaultBases = (PLONE_FIXTURE,)
 
     def setUpZope(self, app, configurationContext):
-        self.loadZCML(package=collective.mailchimp)
+        from mocker import Mocker
+        from mocker import ANY
+        from mocker import KWARGS
+        mocker = Mocker()
+        postmonkey = mocker.replace("postmonkey")
+        mailchimp = postmonkey.PostMonkey(ANY)
+        mocker.count(0, 1000)
+        # Lists
+        mailchimp.lists()
+        mocker.count(0, 1000)
+        mocker.result({
+            u'total': 2,
+            u'data': [
+                {
+                    u'id': u'f6257645gs',
+                    u'web_id': 625,
+                    u'name': u'ACME Newsletter',
+                    u'default_from_name': u'info@acme.com',
+                },
+                {
+                    u'id': u'f6267645gs',
+                    u'web_id': 626,
+                    u'name': u'ACME Newsletter 2',
+                    u'default_from_name': u'info@acme.com',
+                },
+            ]
+        })
+        # List Interest Groupings
+        mailchimp.listInterestGroupings(KWARGS)
+        mocker.count(0, 1000)
+        mocker.result([
+            {
+                u'groups': [
+                    {
+                        u'bit': u'1',
+                        u'display_order': u'1',
+                        u'name': u'Interest Group 1',
+                        u'subscribers': 0
+                    },
+                    {
+                        u'bit': u'2',
+                        u'display_order': u'2',
+                        u'name': u'Interest Group 2',
+                        u'subscribers': 0
+                    },
+                    {
+                        u'bit': u'3',
+                        u'display_order': u'3',
+                        u'name': u'Interest Group 3',
+                        u'subscribers': 1
+                    }
+                ]
+            }
+        ])
+
+        # Get account details
+        mailchimp.getAccountDetails()
+        mocker.count(0, 1000)
+        mocker.result({})
+        result = {  # noqa
+            u'total': 1,
+            u'data': [{
+                u'use_awesomebar': True,
+                u'beamer_address': u'NWVmY2ZkYjjNjc=@campaigns.mailchimp.com',
+                u'web_id': 17241,
+                u'name': u'Test Newsletter',
+                u'email_type_option': False,
+                u'modules': [],
+                u'default_language': u'de',
+                u'default_from_name': u'Timo Stollenwerk',
+                u'visibility': u'pub',
+                u'subscribe_url_long':
+                    u'http://johndoe.us4.list-manage1.com/subscribe?u=5e&id=fd',  # noqa
+                u'default_subject': u'Test Newsletter',
+                u'subscribe_url_short': u'http://eepurl.com/h6Rjg',
+                u'default_from_email': u'no-reply@timostollenwerk.net',
+                u'date_created': u'2011-12-27 16:15:03',
+                u'list_rating': 0,
+                u'id': u'f6257645gs',
+                u'stats': {
+                    u'grouping_count': 0,
+                    u'open_rate': None,
+                    u'member_count': 0,
+                    u'click_rate': None,
+                    u'cleaned_count_since_send': 0,
+                    u'member_count_since_send': 0,
+                    u'target_sub_rate': None,
+                    u'group_count': 0,
+                    u'avg_unsub_rate': None,
+                    u'merge_var_count': 2,
+                    u'unsubscribe_count': 0,
+                    u'cleaned_count': 0,
+                    u'avg_sub_rate': None,
+                    u'unsubscribe_count_since_send': 0,
+                    u'campaign_count': 1
+                    }
+                }
+            ]}
+
+        mocker.replay()
+
+        # Load ZCML
+        import collective.mailchimp
+        xmlconfig.file('configure.zcml',
+                       collective.mailchimp,
+                       context=configurationContext)
 
     def setUpPloneSite(self, portal):
         applyProfile(portal, 'collective.mailchimp:default')
+
         registry = getUtility(IRegistry)
         mailchimp_settings = registry.forInterface(IMailchimpSettings)
-        mailchimp_settings.api_key = u"abcdefg-us2"
-
+        mailchimp_settings.api_key = u"abc"
 
 COLLECTIVE_MAILCHIMP_FIXTURE = CollectiveMailchimp()
-
 COLLECTIVE_MAILCHIMP_INTEGRATION_TESTING = IntegrationTesting(
     bases=(COLLECTIVE_MAILCHIMP_FIXTURE,),
-    name='CollectiveMailchimp:IntegrationTesting'
-)
-
+    name="CollectiveMailchimp:Integration")
 COLLECTIVE_MAILCHIMP_FUNCTIONAL_TESTING = FunctionalTesting(
     bases=(COLLECTIVE_MAILCHIMP_FIXTURE,),
-    name='CollectiveMailchimp:FunctionalTesting'
-)
-
-COLLECTIVE_MAILCHIMP_ACCEPTANCE_TESTING = FunctionalTesting(
-    bases=(
-        COLLECTIVE_MAILCHIMP_FIXTURE,
-        REMOTE_LIBRARY_BUNDLE_FIXTURE,
-        z2.ZSERVER_FIXTURE
-    ),
-    name='CollectiveMailchimp:AcceptanceTesting'
-)
+    name="CollectiveMailchimp:Functional")

--- a/collective/mailchimp/tests/data/account.json
+++ b/collective/mailchimp/tests/data/account.json
@@ -1,0 +1,77 @@
+{
+  "account_id": "8d3a3db4d97663a9074efcc16",
+  "account_name": "Freddie's Jokes",
+  "contact": {
+    "company": "Freddie's Jokes",
+    "addr1": "675 Ponce De Leon Ave NE",
+    "addr2": "Suite 5000",
+    "city": "Atlanta",
+    "state": "GA",
+    "zip": "30308",
+    "country": "US"
+  },
+  "last_login": "2015-09-15 14:25:37",
+  "total_subscribers": 413,
+  "_links": [
+    {
+      "rel": "self",
+      "href": "https://usX.api.mailchimp.com/3.0/",
+      "method": "GET",
+      "targetSchema": "https://api.mailchimp.com/schema/3.0/Root.json"
+    },
+    {
+      "rel": "lists",
+      "href": "https://usX.api.mailchimp.com/3.0/lists",
+      "method": "GET",
+      "targetSchema": "https://api.mailchimp.com/schema/3.0/Lists/Collection.json",
+      "schema": "https://api.mailchimp.com/schema/3.0/CollectionLinks/Lists.json"
+    },
+    {
+      "rel": "reports",
+      "href": "https://usX.api.mailchimp.com/3.0/reports",
+      "method": "GET",
+      "targetSchema": "https://api.mailchimp.com/schema/3.0/Reports/Collection.json",
+      "schema": "https://api.mailchimp.com/schema/3.0/CollectionLinks/Reports.json"
+    },
+    {
+      "rel": "conversations",
+      "href": "https://usX.api.mailchimp.com/3.0/conversations",
+      "method": "GET",
+      "targetSchema": "https://api.mailchimp.com/schema/3.0/Conversations/Collection.json",
+      "schema": "https://api.mailchimp.com/schema/3.0/CollectionLinks/Conversations.json"
+    },
+    {
+      "rel": "campaigns",
+      "href": "https://usX.api.mailchimp.com/3.0/campaigns",
+      "method": "GET",
+      "targetSchema": "https://api.mailchimp.com/schema/3.0/Campaigns/Collection.json",
+      "schema": "https://api.mailchimp.com/schema/3.0/CollectionLinks/Campaigns.json"
+    },
+    {
+      "rel": "automations",
+      "href": "https://usX.api.mailchimp.com/3.0/automations",
+      "method": "GET",
+      "targetSchema": "https://api.mailchimp.com/schema/3.0/Automations/Collection.json",
+      "schema": "https://api.mailchimp.com/schema/3.0/CollectionLinks/Automations.json"
+    },
+    {
+      "rel": "templates",
+      "href": "https://usX.api.mailchimp.com/3.0/templates",
+      "method": "GET",
+      "targetSchema": "https://api.mailchimp.com/schema/3.0/Templates/Collection.json",
+      "schema": "https://api.mailchimp.com/schema/3.0/CollectionLinks/Templates.json"
+    },
+    {
+      "rel": "file-manager",
+      "href": "https://usX.api.mailchimp.com/3.0/file-manager",
+      "method": "GET",
+      "targetSchema": "https://api.mailchimp.com/schema/3.0/FileManager/Namespace.json"
+    },
+    {
+      "rel": "authorized-apps",
+      "href": "https://usX.api.mailchimp.com/3.0/authorized-apps",
+      "method": "GET",
+      "targetSchema": "https://api.mailchimp.com/schema/3.0/AuthorizedApps/Collection.json"
+    }
+  ]
+}

--- a/collective/mailchimp/tests/data/interests.json
+++ b/collective/mailchimp/tests/data/interests.json
@@ -1,0 +1,199 @@
+{
+  "interests": [
+    {
+      "category_id": "a1e9f4b7f6",
+      "list_id": "57afe96172",
+      "id": "9143cf3bd1",
+      "name": "Sometimes you just gotta 'spress yourself.",
+      "display_order": 1,
+      "_links": [
+        {
+          "rel": "self",
+          "href": "https://usX.api.mailchimp.com/3.0/lists/57afe96172/interest-categories/a1e9f4b7f6/interests/9143cf3bd1",
+          "method": "GET",
+          "targetSchema": "https://api.mailchimp.com/schema/3.0/Lists/Interests/Instance.json"
+        },
+        {
+          "rel": "parent",
+          "href": "https://usX.api.mailchimp.com/3.0/lists/57afe96172/interest-categories/a1e9f4b7f6/interests",
+          "method": "GET",
+          "targetSchema": "https://api.mailchimp.com/schema/3.0/Lists/Interests/Collection.json",
+          "schema": "https://api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Interests.json"
+        },
+        {
+          "rel": "update",
+          "href": "https://usX.api.mailchimp.com/3.0/lists/57afe96172/interest-categories/a1e9f4b7f6/interests/9143cf3bd1",
+          "method": "PATCH",
+          "targetSchema": "https://api.mailchimp.com/schema/3.0/Lists/Interests/Instance.json",
+          "schema": "https://api.mailchimp.com/schema/3.0/Lists/Interests/Instance.json"
+        },
+        {
+          "rel": "delete",
+          "href": "https://usX.api.mailchimp.com/3.0/lists/57afe96172/interest-categories/a1e9f4b7f6/interests/9143cf3bd1",
+          "method": "DELETE"
+        }
+      ]
+    },
+    {
+      "category_id": "a1e9f4b7f6",
+      "list_id": "57afe96172",
+      "id": "3a2a927344",
+      "name": "I'm just a poor boy from a poor family.",
+      "display_order": 2,
+      "_links": [
+        {
+          "rel": "self",
+          "href": "https://usX.api.mailchimp.com/3.0/lists/57afe96172/interest-categories/a1e9f4b7f6/interests/3a2a927344",
+          "method": "GET",
+          "targetSchema": "https://api.mailchimp.com/schema/3.0/Lists/Interests/Instance.json"
+        },
+        {
+          "rel": "parent",
+          "href": "https://usX.api.mailchimp.com/3.0/lists/57afe96172/interest-categories/a1e9f4b7f6/interests",
+          "method": "GET",
+          "targetSchema": "https://api.mailchimp.com/schema/3.0/Lists/Interests/Collection.json",
+          "schema": "https://api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Interests.json"
+        },
+        {
+          "rel": "update",
+          "href": "https://usX.api.mailchimp.com/3.0/lists/57afe96172/interest-categories/a1e9f4b7f6/interests/3a2a927344",
+          "method": "PATCH",
+          "targetSchema": "https://api.mailchimp.com/schema/3.0/Lists/Interests/Instance.json",
+          "schema": "https://api.mailchimp.com/schema/3.0/Lists/Interests/Instance.json"
+        },
+        {
+          "rel": "delete",
+          "href": "https://usX.api.mailchimp.com/3.0/lists/57afe96172/interest-categories/a1e9f4b7f6/interests/3a2a927344",
+          "method": "DELETE"
+        }
+      ]
+    },
+    {
+      "category_id": "a1e9f4b7f6",
+      "list_id": "57afe96172",
+      "id": "f9c8f5f0ff",
+      "name": "What's with all these cute kittens?",
+      "display_order": 3,
+      "_links": [
+        {
+          "rel": "self",
+          "href": "https://usX.api.mailchimp.com/3.0/lists/57afe96172/interest-categories/a1e9f4b7f6/interests/f9c8f5f0ff",
+          "method": "GET",
+          "targetSchema": "https://api.mailchimp.com/schema/3.0/Lists/Interests/Instance.json"
+        },
+        {
+          "rel": "parent",
+          "href": "https://usX.api.mailchimp.com/3.0/lists/57afe96172/interest-categories/a1e9f4b7f6/interests",
+          "method": "GET",
+          "targetSchema": "https://api.mailchimp.com/schema/3.0/Lists/Interests/Collection.json",
+          "schema": "https://api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Interests.json"
+        },
+        {
+          "rel": "update",
+          "href": "https://usX.api.mailchimp.com/3.0/lists/57afe96172/interest-categories/a1e9f4b7f6/interests/f9c8f5f0ff",
+          "method": "PATCH",
+          "targetSchema": "https://api.mailchimp.com/schema/3.0/Lists/Interests/Instance.json",
+          "schema": "https://api.mailchimp.com/schema/3.0/Lists/Interests/Instance.json"
+        },
+        {
+          "rel": "delete",
+          "href": "https://usX.api.mailchimp.com/3.0/lists/57afe96172/interest-categories/a1e9f4b7f6/interests/f9c8f5f0ff",
+          "method": "DELETE"
+        }
+      ]
+    },
+    {
+      "category_id": "a1e9f4b7f6",
+      "list_id": "57afe96172",
+      "id": "f231b09abc",
+      "name": "I knock your socks off with my beat box.",
+      "display_order": 4,
+      "_links": [
+        {
+          "rel": "self",
+          "href": "https://usX.api.mailchimp.com/3.0/lists/57afe96172/interest-categories/a1e9f4b7f6/interests/f231b09abc",
+          "method": "GET",
+          "targetSchema": "https://api.mailchimp.com/schema/3.0/Lists/Interests/Instance.json"
+        },
+        {
+          "rel": "parent",
+          "href": "https://usX.api.mailchimp.com/3.0/lists/57afe96172/interest-categories/a1e9f4b7f6/interests",
+          "method": "GET",
+          "targetSchema": "https://api.mailchimp.com/schema/3.0/Lists/Interests/Collection.json",
+          "schema": "https://api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Interests.json"
+        },
+        {
+          "rel": "update",
+          "href": "https://usX.api.mailchimp.com/3.0/lists/57afe96172/interest-categories/a1e9f4b7f6/interests/f231b09abc",
+          "method": "PATCH",
+          "targetSchema": "https://api.mailchimp.com/schema/3.0/Lists/Interests/Instance.json",
+          "schema": "https://api.mailchimp.com/schema/3.0/Lists/Interests/Instance.json"
+        },
+        {
+          "rel": "delete",
+          "href": "https://usX.api.mailchimp.com/3.0/lists/57afe96172/interest-categories/a1e9f4b7f6/interests/f231b09abc",
+          "method": "DELETE"
+        }
+      ]
+    },
+    {
+      "category_id": "a1e9f4b7f6",
+      "list_id": "57afe96172",
+      "id": "bd6e66465f",
+      "name": "Two chimps walk into a bar. The other chimp ducks.",
+      "display_order": 5,
+      "_links": [
+        {
+          "rel": "self",
+          "href": "https://usX.api.mailchimp.com/3.0/lists/57afe96172/interest-categories/a1e9f4b7f6/interests/bd6e66465f",
+          "method": "GET",
+          "targetSchema": "https://api.mailchimp.com/schema/3.0/Lists/Interests/Instance.json"
+        },
+        {
+          "rel": "parent",
+          "href": "https://usX.api.mailchimp.com/3.0/lists/57afe96172/interest-categories/a1e9f4b7f6/interests",
+          "method": "GET",
+          "targetSchema": "https://api.mailchimp.com/schema/3.0/Lists/Interests/Collection.json",
+          "schema": "https://api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Interests.json"
+        },
+        {
+          "rel": "update",
+          "href": "https://usX.api.mailchimp.com/3.0/lists/57afe96172/interest-categories/a1e9f4b7f6/interests/bd6e66465f",
+          "method": "PATCH",
+          "targetSchema": "https://api.mailchimp.com/schema/3.0/Lists/Interests/Instance.json",
+          "schema": "https://api.mailchimp.com/schema/3.0/Lists/Interests/Instance.json"
+        },
+        {
+          "rel": "delete",
+          "href": "https://usX.api.mailchimp.com/3.0/lists/57afe96172/interest-categories/a1e9f4b7f6/interests/bd6e66465f",
+          "method": "DELETE"
+        }
+      ]
+    }
+  ],
+  "list_id": "57afe96172",
+  "category_id": "a1e9f4b7f6",
+  "_links": [
+    {
+      "rel": "self",
+      "href": "https://usX.api.mailchimp.com/3.0/lists/57afe96172/interest-categories/a1e9f4b7f6/interests",
+      "method": "GET",
+      "targetSchema": "https://api.mailchimp.com/schema/3.0/Lists/Interests/Collection.json",
+      "schema": "https://api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Interests.json"
+    },
+    {
+      "rel": "parent",
+      "href": "https://usX.api.mailchimp.com/3.0/lists/57afe96172/interest-categories/a1e9f4b7f6",
+      "method": "GET",
+      "targetSchema": "https://api.mailchimp.com/schema/3.0/Lists/InterestCategories/Instance.json"
+    },
+    {
+      "rel": "create",
+      "href": "https://usX.api.mailchimp.com/3.0/lists/57afe96172/interest-categories/a1e9f4b7f6/interests",
+      "method": "POST",
+      "targetSchema": "https://api.mailchimp.com/schema/3.0/Lists/Interests/Instance.json",
+      "schema": "https://api.mailchimp.com/schema/3.0/Lists/Interests/Instance.json"
+    }
+  ],
+  "total_items": 5
+}

--- a/collective/mailchimp/tests/data/lists.json
+++ b/collective/mailchimp/tests/data/lists.json
@@ -1,0 +1,176 @@
+{
+  "lists": [
+    {
+      "id": "f6257645gs",
+      "name": "ACME Newsletter",
+      "campaign_defaults": {
+        "from_name": "ACME Newsletter",
+        "from_email": "info@acme.com",
+        "subject": "",
+        "language": "en"
+      }
+    },
+    {
+      "id": "f6267645gs",
+      "name": "ACME Newsletter 2",
+      "campaign_defaults": {
+        "from_name": "ACME Newsletter 2",
+        "from_email": "info@acme.com",
+        "subject": "",
+        "language": "en"
+      }
+    },
+    {
+      "id": "57afe96172",
+      "name": "Freddie's Jokes",
+      "contact": {
+        "company": "MailChimp",
+        "address1": "675 Ponce De Leon Ave NE",
+        "address2": "Suite 5000",
+        "city": "Atlanta",
+        "state": "GA",
+        "zip": "30308",
+        "country": "US",
+        "phone": ""
+      },
+      "permission_reminder": "You're receiving this email because you just can't get enough of Freddie's jokes.",
+      "use_archive_bar": false,
+      "campaign_defaults": {
+        "from_name": "Freddie",
+        "from_email": "freddie@freddiesjokes.com",
+        "subject": "",
+        "language": "en"
+      },
+      "notify_on_subscribe": "",
+      "notify_on_unsubscribe": "",
+      "date_created": "2015-09-15T14:38:16+00:00",
+      "list_rating": 3,
+      "email_type_option": false,
+      "subscribe_url_short": "http://eepurl.com/xxxx",
+      "subscribe_url_long": "http://freddiesjokes.usX.list-manage.com/subscribe?u=8d3a3db4d97663a9074efcc16&id=xxxx",
+      "beamer_address": "usX-xxxx-xxxx@inbound.mailchimp.com",
+      "visibility": "prv",
+      "modules": [],
+      "stats": {
+        "member_count": 203,
+        "unsubscribe_count": 0,
+        "cleaned_count": 0,
+        "member_count_since_send": 0,
+        "unsubscribe_count_since_send": 0,
+        "cleaned_count_since_send": 0,
+        "campaign_count": 3,
+        "campaign_last_sent": "",
+        "merge_field_count": 2,
+        "avg_sub_rate": 15,
+        "avg_unsub_rate": 0,
+        "target_sub_rate": 0,
+        "open_rate": 0,
+        "click_rate": 0,
+        "last_sub_date": "2015-09-15T17:27:16+00:00",
+        "last_unsub_date": ""
+      },
+      "_links": [
+        {
+          "rel": "self",
+          "href": "https://usX.api.mailchimp.com/3.0/lists/57afe96172",
+          "method": "GET",
+          "targetSchema": "https://api.mailchimp.com/schema/3.0/Lists/Instance.json"
+        },
+        {
+          "rel": "parent",
+          "href": "https://usX.api.mailchimp.com/3.0/lists",
+          "method": "GET",
+          "targetSchema": "https://api.mailchimp.com/schema/3.0/Lists/Collection.json",
+          "schema": "https://api.mailchimp.com/schema/3.0/CollectionLinks/Lists.json"
+        },
+        {
+          "rel": "update",
+          "href": "https://usX.api.mailchimp.com/3.0/lists/57afe96172",
+          "method": "PATCH",
+          "schema": "https://api.mailchimp.com/schema/3.0/Lists/Instance.json"
+        },
+        {
+          "rel": "delete",
+          "href": "https://usX.api.mailchimp.com/3.0/lists/57afe96172",
+          "method": "DELETE"
+        },
+        {
+          "rel": "abuse-reports",
+          "href": "https://usX.api.mailchimp.com/3.0/lists/57afe96172/abuse-reports",
+          "method": "GET",
+          "targetSchema": "https://api.mailchimp.com/schema/3.0/Lists/Abuse/Collection.json",
+          "schema": "https://api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Abuse.json"
+        },
+        {
+          "rel": "activity",
+          "href": "https://usX.api.mailchimp.com/3.0/lists/57afe96172/activity",
+          "method": "GET",
+          "targetSchema": "https://api.mailchimp.com/schema/3.0/Lists/Activity/Collection.json"
+        },
+        {
+          "rel": "clients",
+          "href": "https://usX.api.mailchimp.com/3.0/lists/57afe96172/clients",
+          "method": "GET",
+          "targetSchema": "https://api.mailchimp.com/schema/3.0/Lists/Clients/Collection.json"
+        },
+        {
+          "rel": "growth-history",
+          "href": "https://usX.api.mailchimp.com/3.0/lists/57afe96172/growth-history",
+          "method": "GET",
+          "targetSchema": "https://api.mailchimp.com/schema/3.0/Lists/Growth/Collection.json",
+          "schema": "https://api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Growth.json"
+        },
+        {
+          "rel": "interest-categories",
+          "href": "https://usX.api.mailchimp.com/3.0/lists/57afe96172/interest-categories",
+          "method": "GET",
+          "targetSchema": "https://api.mailchimp.com/schema/3.0/Lists/InterestCategories/Collection.json",
+          "schema": "https://api.mailchimp.com/schema/3.0/CollectionLinks/Lists/InterestCategories.json"
+        },
+        {
+          "rel": "members",
+          "href": "https://usX.api.mailchimp.com/3.0/lists/57afe96172/members",
+          "method": "GET",
+          "targetSchema": "https://api.mailchimp.com/schema/3.0/Lists/Members/Collection.json",
+          "schema": "https://api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Members.json"
+        },
+        {
+          "rel": "merge-fields",
+          "href": "https://usX.api.mailchimp.com/3.0/lists/57afe96172/merge-fields",
+          "method": "GET",
+          "targetSchema": "https://api.mailchimp.com/schema/3.0/Lists/MergeFields/Collection.json",
+          "schema": "https://api.mailchimp.com/schema/3.0/CollectionLinks/Lists/MergeFields.json"
+        },
+        {
+          "rel": "segments",
+          "href": "https://usX.api.mailchimp.com/3.0/lists/57afe96172/segments",
+          "method": "GET",
+          "targetSchema": "https://api.mailchimp.com/schema/3.0/Lists/Segments/Collection.json",
+          "schema": "https://api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Segments.json"
+        }
+      ]
+    }
+  ],
+  "_links": [
+    {
+      "rel": "self",
+      "href": "https://usX.api.mailchimp.com/3.0/lists",
+      "method": "GET",
+      "targetSchema": "https://api.mailchimp.com/schema/3.0/Lists/Collection.json",
+      "schema": "https://api.mailchimp.com/schema/3.0/CollectionLinks/Lists.json"
+    },
+    {
+      "rel": "parent",
+      "href": "https://usX.api.mailchimp.com/3.0/",
+      "method": "GET",
+      "targetSchema": "https://api.mailchimp.com/schema/3.0/Root.json"
+    },
+    {
+      "rel": "create",
+      "href": "https://usX.api.mailchimp.com/3.0/lists",
+      "method": "POST",
+      "schema": "https://api.mailchimp.com/schema/3.0/Lists/Instance.json"
+    }
+  ],
+  "total_items": 1
+}

--- a/collective/mailchimp/tests/data/lists_interest_categories.json
+++ b/collective/mailchimp/tests/data/lists_interest_categories.json
@@ -1,0 +1,69 @@
+{
+  "list_id": "57afe96172",
+  "categories": [
+    {
+      "list_id": "57afe96172",
+      "id": "a1e9f4b7f6",
+      "title": "Favorite Freddie Joke",
+      "display_order": 0,
+      "type": "checkboxes",
+      "_links": [
+        {
+          "rel": "self",
+          "href": "https://usX.api.mailchimp.com/3.0/lists/57afe96172/interest-categories/a1e9f4b7f6",
+          "method": "GET",
+          "targetSchema": "https://api.mailchimp.com/schema/3.0/Lists/InterestCategories/Instance.json"
+        },
+        {
+          "rel": "parent",
+          "href": "https://usX.api.mailchimp.com/3.0/lists/57afe96172/interest-categories",
+          "method": "GET",
+          "targetSchema": "https://api.mailchimp.com/schema/3.0/Lists/InterestCategories/Collection.json",
+          "schema": "https://api.mailchimp.com/schema/3.0/CollectionLinks/Lists/InterestCategories.json"
+        },
+        {
+          "rel": "update",
+          "href": "https://usX.api.mailchimp.com/3.0/lists/57afe96172/interest-categories/a1e9f4b7f6",
+          "method": "PATCH",
+          "targetSchema": "https://api.mailchimp.com/schema/3.0/Lists/InterestCategories/Instance.json",
+          "schema": "https://api.mailchimp.com/schema/3.0/Lists/InterestCategories/Instance.json"
+        },
+        {
+          "rel": "delete",
+          "href": "https://usX.api.mailchimp.com/3.0/lists/57afe96172/interest-categories/a1e9f4b7f6",
+          "method": "DELETE"
+        },
+        {
+          "rel": "interests",
+          "href": "https://usX.api.mailchimp.com/3.0/lists/57afe96172/interest-categories/a1e9f4b7f6/interests",
+          "method": "GET",
+          "targetSchema": "https://api.mailchimp.com/schema/3.0/Lists/Interests/Collection.json",
+          "schema": "https://api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Interests.json"
+        }
+      ]
+    }
+  ],
+  "_links": [
+    {
+      "rel": "self",
+      "href": "https://usX.api.mailchimp.com/3.0/lists/57afe96172/interest-categories",
+      "method": "GET",
+      "targetSchema": "https://api.mailchimp.com/schema/3.0/Lists/InterestCategories/Collection.json",
+      "schema": "https://api.mailchimp.com/schema/3.0/CollectionLinks/Lists/InterestCategories.json"
+    },
+    {
+      "rel": "parent",
+      "href": "https://usX.api.mailchimp.com/3.0/lists/57afe96172/",
+      "method": "GET",
+      "targetSchema": "https://api.mailchimp.com/schema/3.0/Lists/Instance.json"
+    },
+    {
+      "rel": "create",
+      "href": "https://usX.api.mailchimp.com/3.0/lists/57afe96172/interest-categories",
+      "method": "POST",
+      "targetSchema": "https://api.mailchimp.com/schema/3.0/Lists/InterestCategories/Instance.json",
+      "schema": "https://api.mailchimp.com/schema/3.0/Lists/InterestCategories/Instance.json"
+    }
+  ],
+  "total_items": 1
+}

--- a/collective/mailchimp/tests/test_controlpanel.py
+++ b/collective/mailchimp/tests/test_controlpanel.py
@@ -1,7 +1,7 @@
 from plone.app.testing import SITE_OWNER_NAME
 from plone.app.testing import SITE_OWNER_PASSWORD
 from plone.testing.z2 import Browser
-import unittest2 as unittest
+import unittest
 
 from zope.component import getMultiAdapter
 

--- a/collective/mailchimp/tests/test_exceptions.py
+++ b/collective/mailchimp/tests/test_exceptions.py
@@ -1,12 +1,8 @@
 import unittest
 
-from zope.component import getUtility
-
-from collective.mailchimp.testing import \
-    COLLECTIVE_MAILCHIMP_INTEGRATION_TESTING
-
 
 class TestExceptions(unittest.TestCase):
+
     def test_SerializationError_captures_obj(self):
         from ..exceptions import SerializationError
         dummy_obj = object()

--- a/collective/mailchimp/tests/test_exceptions.py
+++ b/collective/mailchimp/tests/test_exceptions.py
@@ -27,8 +27,12 @@ class TestExceptions(unittest.TestCase):
     def test_MailChimpException_attrs(self):
         from ..exceptions import MailChimpException
         code = -90
-        error = 'Method fake_method is not exported by this server'
-        exc = MailChimpException(code, error)
+        detail = 'Method fake_method is not exported by this server'
+        errors = [{"field": "interests",
+                   "message": "Schema describes object, array found instead"}]
+        exc = MailChimpException(code, detail, errors)
         self.assertEqual(exc.code, code)
-        self.assertEqual(exc.error, error)
-        self.assertIn(error, exc.__str__())
+        self.assertEqual(exc.detail, detail)
+        self.assertEqual(exc.errors, errors)
+        self.assertIn(detail, exc.__str__())
+        self.assertIn('interests', exc.__str__())

--- a/collective/mailchimp/tests/test_exceptions.py
+++ b/collective/mailchimp/tests/test_exceptions.py
@@ -1,0 +1,38 @@
+import unittest
+
+from zope.component import getUtility
+
+from collective.mailchimp.testing import \
+    COLLECTIVE_MAILCHIMP_INTEGRATION_TESTING
+
+
+class TestExceptions(unittest.TestCase):
+    def test_SerializationError_captures_obj(self):
+        from ..exceptions import SerializationError
+        dummy_obj = object()
+        error = SerializationError(dummy_obj)
+        self.assertEqual(error.obj, dummy_obj)
+        self.assertIn(dummy_obj.__str__(), error.__str__())
+
+    def test_DeserializationError_captures_obj(self):
+        from ..exceptions import DeserializationError
+        dummy_obj = object()
+        error = DeserializationError(dummy_obj)
+        self.assertEqual(error.obj, dummy_obj)
+        self.assertIn(dummy_obj.__str__(), error.__str__())
+
+    def test_PostRequestError_captures_exc(self):
+        from ..exceptions import PostRequestError
+        exc = Exception()
+        caught = PostRequestError(exc)
+        self.assertEqual(caught.exc, exc)
+        self.assertIn(exc.__str__(), caught.__str__())
+
+    def test_MailChimpException_attrs(self):
+        from ..exceptions import MailChimpException
+        code = -90
+        error = 'Method fake_method is not exported by this server'
+        exc = MailChimpException(code, error)
+        self.assertEqual(exc.code, code)
+        self.assertEqual(exc.error, error)
+        self.assertIn(error, exc.__str__())

--- a/collective/mailchimp/tests/test_locator.py
+++ b/collective/mailchimp/tests/test_locator.py
@@ -21,24 +21,29 @@ class MailchimpLocatorIntegrationTest(unittest.TestCase):
         from collective.mailchimp.interfaces import IMailchimpLocator
         self.assertTrue(getUtility(IMailchimpLocator))
 
-    def test_mailchimp_locator_connect_method(self):
+    def test_mailchimp_locator_initialize_method(self):
         from collective.mailchimp.locator import MailchimpLocator
         locator = MailchimpLocator()
-        locator.connect()
-        self.assertTrue(locator.mailchimp is not False)
+        self.assertEqual(locator.registry, None)
+        self.assertEqual(locator.settings, None)
+        self.assertEqual(locator.api_root, None)
+        locator.initialize()
+        self.assertTrue(locator.registry)
+        self.assertTrue(locator.settings)
+        self.assertTrue(locator.api_root)
 
     def test_mailchimp_locator_lists_method(self):
         from collective.mailchimp.locator import MailchimpLocator
         locator = MailchimpLocator()
         self.assertTrue(locator.lists())
-        self.assertEqual(len(locator.lists()), 2)
+        self.assertEqual(len(locator.lists()), 3)
 
     def test_mailchimp_locator_groups_method(self):
         from collective.mailchimp.locator import MailchimpLocator
         locator = MailchimpLocator()
-        self.assertTrue(locator.groups(list_id=u'a1346945ab'))
+        self.assertTrue(locator.groups(list_id=u'57afe96172'))
         self.assertEqual(
-            len(locator.groups(list_id=u'a1346945ab')['groups']), 3)
+            len(locator.groups(list_id=u'57afe96172')['categories']), 1)
 
     def test_mailchimp_locator_updateCache_method(self):
         from collective.mailchimp.locator import MailchimpLocator
@@ -52,16 +57,17 @@ class MailchimpLocatorIntegrationTest(unittest.TestCase):
         # self.assertEqual(locator.registry[locator.key_groups], None)
         # self.assertEqual(locator.registry[locator.key_lists], None)
         locator.updateCache()
-        self.assertTrue(
-            isinstance(locator.registry[locator.key_account], dict))
-        self.assertEqual(locator.registry[locator.key_account], {})
+        account = locator.registry[locator.key_account]
+        self.assertTrue(isinstance(account, dict))
+        self.assertEqual(account[u'account_id'], u'8d3a3db4d97663a9074efcc16')
+        self.assertEqual(account[u'account_name'], u"Freddie's Jokes")
         self.assertTrue(
             isinstance(locator.registry[locator.key_groups], dict))
         self.assertEqual(locator.registry[locator.key_groups].keys(),
-                         [u'f6257645gs', u'f6267645gs'])
+                         [u'f6257645gs', u'f6267645gs', u'57afe96172'])
         self.assertTrue(
             isinstance(locator.registry[locator.key_lists], tuple))
-        self.assertEqual(len(locator.registry[locator.key_lists]), 2)
+        self.assertEqual(len(locator.registry[locator.key_lists]), 3)
         # It does not complain when there is no api key
         locator.settings.api_key = None
         locator.updateCache()

--- a/collective/mailchimp/tests/test_locator.py
+++ b/collective/mailchimp/tests/test_locator.py
@@ -43,7 +43,6 @@ class MailchimpLocatorIntegrationTest(unittest.TestCase):
     def test_mailchimp_locator_updateCache_method(self):
         from collective.mailchimp.locator import MailchimpLocator
         locator = MailchimpLocator()
-        locator.initialize()
         # These tests pass when we run this test method separately,
         # but fail when running all tests.  Skip them because they are
         # not what we really want to test here.

--- a/collective/mailchimp/tests/test_locator.py
+++ b/collective/mailchimp/tests/test_locator.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import unittest2 as unittest
+import unittest
 
 from zope.component import getUtility
 
@@ -21,15 +21,18 @@ class MailchimpLocatorIntegrationTest(unittest.TestCase):
         from collective.mailchimp.interfaces import IMailchimpLocator
         self.assertTrue(getUtility(IMailchimpLocator))
 
-    def test_mailchimp_locator_connect_method(self):
+    def test_mailchimp_locator_initializ_method(self):
         from collective.mailchimp.locator import MailchimpLocator
         locator = MailchimpLocator()
-        locator.connect()
-        self.assertTrue(locator.mailchimp is not False)
+        locator.initialize()
+        self.assertTrue(locator.apikey is not False)
+        self.assertTrue(locator.settings is not False)
 
     def test_mailchimp_locator_lists_method(self):
         from collective.mailchimp.locator import MailchimpLocator
         locator = MailchimpLocator()
+        # TODO: results depend on responses from mailchimp server.
+        #       we should fix the mocks.
         self.assertTrue(locator.lists())
         self.assertEqual(len(locator.lists()), 2)
 
@@ -38,7 +41,7 @@ class MailchimpLocatorIntegrationTest(unittest.TestCase):
         locator = MailchimpLocator()
         self.assertTrue(locator.groups(list_id=u'a1346945ab'))
         self.assertEqual(
-            len(locator.groups(list_id=u'a1346945ab')['groups']), 3)
+            len(locator.groups(list_id=u'a1346945ab')['categories']), 3)
 
     def test_mailchimp_locator_updateCache_method(self):
         from collective.mailchimp.locator import MailchimpLocator

--- a/collective/mailchimp/tests/test_locator.py
+++ b/collective/mailchimp/tests/test_locator.py
@@ -21,18 +21,15 @@ class MailchimpLocatorIntegrationTest(unittest.TestCase):
         from collective.mailchimp.interfaces import IMailchimpLocator
         self.assertTrue(getUtility(IMailchimpLocator))
 
-    def test_mailchimp_locator_initializ_method(self):
+    def test_mailchimp_locator_connect_method(self):
         from collective.mailchimp.locator import MailchimpLocator
         locator = MailchimpLocator()
-        locator.initialize()
-        self.assertTrue(locator.apikey is not False)
-        self.assertTrue(locator.settings is not False)
+        locator.connect()
+        self.assertTrue(locator.mailchimp is not False)
 
     def test_mailchimp_locator_lists_method(self):
         from collective.mailchimp.locator import MailchimpLocator
         locator = MailchimpLocator()
-        # TODO: results depend on responses from mailchimp server.
-        #       we should fix the mocks.
         self.assertTrue(locator.lists())
         self.assertEqual(len(locator.lists()), 2)
 
@@ -41,11 +38,12 @@ class MailchimpLocatorIntegrationTest(unittest.TestCase):
         locator = MailchimpLocator()
         self.assertTrue(locator.groups(list_id=u'a1346945ab'))
         self.assertEqual(
-            len(locator.groups(list_id=u'a1346945ab')['categories']), 3)
+            len(locator.groups(list_id=u'a1346945ab')['groups']), 3)
 
     def test_mailchimp_locator_updateCache_method(self):
         from collective.mailchimp.locator import MailchimpLocator
         locator = MailchimpLocator()
+        locator.initialize()
         # These tests pass when we run this test method separately,
         # but fail when running all tests.  Skip them because they are
         # not what we really want to test here.

--- a/collective/mailchimp/tests/test_locator.py
+++ b/collective/mailchimp/tests/test_locator.py
@@ -41,9 +41,12 @@ class MailchimpLocatorIntegrationTest(unittest.TestCase):
     def test_mailchimp_locator_groups_method(self):
         from collective.mailchimp.locator import MailchimpLocator
         locator = MailchimpLocator()
-        self.assertTrue(locator.groups(list_id=u'57afe96172'))
-        self.assertEqual(
-            len(locator.groups(list_id=u'57afe96172')['categories']), 1)
+        groups = locator.groups(list_id=u'57afe96172')
+        self.assertTrue(groups)
+        self.assertEqual(len(groups['categories']), 1)
+        self.assertEqual(len(groups['interests']), 5)
+        self.assertEqual(groups['interests'][0]['name'],
+                         u"Sometimes you just gotta 'spress yourself.")
 
     def test_mailchimp_locator_updateCache_method(self):
         from collective.mailchimp.locator import MailchimpLocator
@@ -61,10 +64,15 @@ class MailchimpLocatorIntegrationTest(unittest.TestCase):
         self.assertTrue(isinstance(account, dict))
         self.assertEqual(account[u'account_id'], u'8d3a3db4d97663a9074efcc16')
         self.assertEqual(account[u'account_name'], u"Freddie's Jokes")
-        self.assertTrue(
-            isinstance(locator.registry[locator.key_groups], dict))
-        self.assertEqual(locator.registry[locator.key_groups].keys(),
+        groups = locator.registry[locator.key_groups]
+        self.assertTrue(isinstance(groups, dict))
+        self.assertEqual(groups.keys(),
                          [u'f6257645gs', u'f6267645gs', u'57afe96172'])
+        self.assertEqual(
+            groups[groups.keys()[0]].keys(),
+            [u'total_items', 'interests', u'_links', u'categories', u'list_id']
+            )
+
         self.assertTrue(
             isinstance(locator.registry[locator.key_lists], tuple))
         self.assertEqual(len(locator.registry[locator.key_lists]), 3)

--- a/collective/mailchimp/tests/test_mock_requests.py
+++ b/collective/mailchimp/tests/test_mock_requests.py
@@ -1,0 +1,56 @@
+from collective.mailchimp.testing import \
+    COLLECTIVE_MAILCHIMP_INTEGRATION_TESTING
+from collective.mailchimp.testing import DUMMY_API_KEY
+from collective.mailchimp.testing import MockRequestsException
+from collective.mailchimp.testing import TEST_DATA_DIR
+import os
+import unittest
+
+
+class MockRequestsTests(unittest.TestCase):
+    """Test the mocking we do to the requests module.
+
+    We only mock the requests module that is imported in locator.py.
+    """
+
+    layer = COLLECTIVE_MAILCHIMP_INTEGRATION_TESTING
+
+    def test_locator_requests_error(self):
+        # Test that our mock exceptions are raised.  We try to raise them all
+        # here, but it seems overkill to test the messages of the exceptions.
+        from collective.mailchimp.locator import requests
+        self.assertRaises(MockRequestsException, requests.get)
+        self.assertRaises(MockRequestsException, requests.get, '')
+        self.assertRaises(MockRequestsException, requests.get,
+                          'http://website.unavailable')
+        url = 'https://api.mailchimp.com/3.0/'
+        self.assertRaises(MockRequestsException, requests.get, url)
+        auth = ('apikey', DUMMY_API_KEY)
+        self.assertRaises(MockRequestsException, requests.get, url,
+                          auth=auth)
+        self.assertRaises(MockRequestsException, requests.get, url,
+                          auth=auth, data='')
+        self.assertRaises(ValueError, requests.get, url,
+                          auth=auth, data='{bad json')
+
+    def test_locator_requests_success(self):
+        # Test that a correct api request is answered with our mock data.
+        from collective.mailchimp.locator import requests
+        url = 'https://api.mailchimp.com/3.0/'
+        auth = ('apikey', DUMMY_API_KEY)
+        response = requests.get(
+            url,
+            auth=auth,
+            data='{}')
+        path = os.path.join(TEST_DATA_DIR, 'account.json')
+        with open(path) as datafile:
+            expected_text = datafile.read()
+        self.assertEqual(response.text, expected_text)
+
+    def test_standard_requests_error(self):
+        # Test that the normal exceptions are raised.
+        import requests
+        self.assertRaises(TypeError, requests.get)
+        self.assertRaises(ValueError, requests.get, '')
+        self.assertRaises(requests.exceptions.ConnectionError, requests.get,
+                          'http://website.unavailable')

--- a/collective/mailchimp/tests/test_newsletter.py
+++ b/collective/mailchimp/tests/test_newsletter.py
@@ -2,7 +2,7 @@
 from plone.app.testing import SITE_OWNER_NAME
 from plone.app.testing import SITE_OWNER_PASSWORD
 from plone.testing.z2 import Browser
-import unittest2 as unittest
+import unittest
 
 from collective.mailchimp.testing import \
     COLLECTIVE_MAILCHIMP_INTEGRATION_TESTING

--- a/collective/mailchimp/tests/test_portlet.py
+++ b/collective/mailchimp/tests/test_portlet.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import unittest2 as unittest
+import unittest
 from plone.testing.z2 import Browser
 from plone.app.testing import TEST_USER_ID
 from plone.app.testing import SITE_OWNER_NAME

--- a/collective/mailchimp/tests/test_portlet.py
+++ b/collective/mailchimp/tests/test_portlet.py
@@ -128,27 +128,6 @@ class TestPortletIntegration(unittest.TestCase):
             'Basic %s:%s' % (SITE_OWNER_NAME, SITE_OWNER_PASSWORD,)
         )
 
-    def test_postmonkey_mocker(self):
-        from postmonkey import PostMonkey
-        mailchimp = PostMonkey(u"abc")
-        self.assertEqual(mailchimp.lists(), {
-            u'total': 2,
-            u'data': [
-                {
-                    u'id': u'f6257645gs',
-                    u'web_id': 625,
-                    u'name': u'ACME Newsletter',
-                    u'default_from_name': u'info@acme.com',
-                },
-                {
-                    u'id': u'f6267645gs',
-                    u'web_id': 626,
-                    u'name': u'ACME Newsletter 2',
-                    u'default_from_name': u'info@acme.com',
-                }
-            ]
-        })
-
     def test_add_portlet_form(self):
         self.browser.open(
             self.portal_url +

--- a/collective/mailchimp/tests/test_setup.py
+++ b/collective/mailchimp/tests/test_setup.py
@@ -1,9 +1,9 @@
-import unittest2 as unittest
-
+# -*- coding: utf-8 -*-
 from Products.CMFCore.utils import getToolByName
-
 from collective.mailchimp.testing import \
     COLLECTIVE_MAILCHIMP_INTEGRATION_TESTING
+from plone import api
+import unittest
 
 
 class TestSetup(unittest.TestCase):
@@ -12,12 +12,17 @@ class TestSetup(unittest.TestCase):
 
     def setUp(self):
         self.portal = self.layer['portal']
-        self.request = self.layer['request']
+        self.request = self.layer['request']        
+
+    def test_product_installed(self):
+        """Test if collective.mailchimp is installed."""
+        self.assertTrue(self.installer.isProductInstalled(
+            'collective.mailchimp'))
 
     def test_browserlayer_available(self):
         from plone.browserlayer import utils
         from collective.mailchimp.interfaces import ICollectiveMailchimp
-        self.failUnless(ICollectiveMailchimp in utils.registered_layers())
+        self.assertIn(ICollectiveMailchimp, utils.registered_layers())
 
     def test_mailchimp_css_available(self):
         cssreg = getToolByName(self.portal, "portal_css")
@@ -38,3 +43,29 @@ class TestSetup(unittest.TestCase):
 
 def test_suite():
     return unittest.defaultTestLoader.loadTestsFromName(__name__)
+
+
+    def setUp(self):
+        """Custom shared utility setup for tests."""
+        self.portal = self.layer['portal']
+
+
+class TestUninstall(unittest.TestCase):
+
+    layer = COLLECTIVE_MAILCHIMP_INTEGRATION_TESTING
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+        self.installer = api.portal.get_tool('portal_quickinstaller')
+        self.installer.uninstallProducts(['collective.mailchimp'])
+
+    def test_product_uninstalled(self):
+        """Test if collective.mailchimp is cleanly uninstalled."""
+        self.assertFalse(self.installer.isProductInstalled(
+            'collective.mailchimp'))
+
+    def test_browserlayer_removed(self):
+        """Test that ICollectiveMailchimp is removed."""
+        from collective.mailchimp.interfaces import ICollectiveMailchimp
+        from plone.browserlayer import utils
+        self.assertNotIn(ICollectiveMailchimp, utils.registered_layers())

--- a/collective/mailchimp/tests/test_setup.py
+++ b/collective/mailchimp/tests/test_setup.py
@@ -44,7 +44,6 @@ class TestSetup(unittest.TestCase):
 def test_suite():
     return unittest.defaultTestLoader.loadTestsFromName(__name__)
 
-
     def setUp(self):
         """Custom shared utility setup for tests."""
         self.portal = self.layer['portal']

--- a/collective/mailchimp/tests/test_setup.py
+++ b/collective/mailchimp/tests/test_setup.py
@@ -1,8 +1,8 @@
-# -*- coding: utf-8 -*-
 from Products.CMFCore.utils import getToolByName
+
 from collective.mailchimp.testing import \
     COLLECTIVE_MAILCHIMP_INTEGRATION_TESTING
-from plone import api
+
 import unittest
 
 
@@ -14,15 +14,10 @@ class TestSetup(unittest.TestCase):
         self.portal = self.layer['portal']
         self.request = self.layer['request']
 
-    def test_product_installed(self):
-        """Test if collective.mailchimp is installed."""
-        self.assertTrue(self.installer.isProductInstalled(
-            'collective.mailchimp'))
-
     def test_browserlayer_available(self):
         from plone.browserlayer import utils
         from collective.mailchimp.interfaces import ICollectiveMailchimp
-        self.assertIn(ICollectiveMailchimp, utils.registered_layers())
+        self.failUnless(ICollectiveMailchimp in utils.registered_layers())
 
     def test_mailchimp_css_available(self):
         cssreg = getToolByName(self.portal, "portal_css")
@@ -43,28 +38,3 @@ class TestSetup(unittest.TestCase):
 
 def test_suite():
     return unittest.defaultTestLoader.loadTestsFromName(__name__)
-
-    def setUp(self):
-        """Custom shared utility setup for tests."""
-        self.portal = self.layer['portal']
-
-
-class TestUninstall(unittest.TestCase):
-
-    layer = COLLECTIVE_MAILCHIMP_INTEGRATION_TESTING
-
-    def setUp(self):
-        self.portal = self.layer['portal']
-        self.installer = api.portal.get_tool('portal_quickinstaller')
-        self.installer.uninstallProducts(['collective.mailchimp'])
-
-    def test_product_uninstalled(self):
-        """Test if collective.mailchimp is cleanly uninstalled."""
-        self.assertFalse(self.installer.isProductInstalled(
-            'collective.mailchimp'))
-
-    def test_browserlayer_removed(self):
-        """Test that ICollectiveMailchimp is removed."""
-        from collective.mailchimp.interfaces import ICollectiveMailchimp
-        from plone.browserlayer import utils
-        self.assertNotIn(ICollectiveMailchimp, utils.registered_layers())

--- a/collective/mailchimp/vocabularies.py
+++ b/collective/mailchimp/vocabularies.py
@@ -32,7 +32,7 @@ def interest_groups(context):
     groups = mailchimp.groups(list_id=list_id)
     if not groups:
         return SimpleVocabulary([])
-    groups = groups['groups']
+    groups = groups['categories']
     return SimpleVocabulary([
         SimpleTerm(
             value=group['name'].encode("utf-8"),
@@ -55,13 +55,6 @@ def email_type(context):
             value='html',
             token='html',
             title='HTML',
-        )
-    )
-    terms.append(
-        SimpleTerm(
-            value='mobile',
-            token='mobile',
-            title='Mobile',
         )
     )
     return SimpleVocabulary(terms)

--- a/collective/mailchimp/vocabularies.py
+++ b/collective/mailchimp/vocabularies.py
@@ -32,12 +32,17 @@ def interest_groups(context):
     groups = mailchimp.groups(list_id=list_id)
     if not groups:
         return SimpleVocabulary([])
-    groups = groups['categories']
+    # Each category has a list of options/groups/interests.  We only support
+    # one interest category per list.  We take the first one.  We have stored
+    # this in the interests key.
+    interests = groups.get('interests')
+    if not interests:
+        return SimpleVocabulary([])
     return SimpleVocabulary([
         SimpleTerm(
-            value=group['title'].encode("utf-8"),
-            title=group['title']
-        ) for group in groups
+            value=group['id'].encode("utf-8"),
+            title=group['name']
+        ) for group in interests
     ])
 
 

--- a/collective/mailchimp/vocabularies.py
+++ b/collective/mailchimp/vocabularies.py
@@ -35,8 +35,8 @@ def interest_groups(context):
     groups = groups['categories']
     return SimpleVocabulary([
         SimpleTerm(
-            value=group['name'].encode("utf-8"),
-            title=group['name']
+            value=group['title'].encode("utf-8"),
+            title=group['title']
         ) for group in groups
     ])
 

--- a/plone4.cfg
+++ b/plone4.cfg
@@ -1,0 +1,5 @@
+[buildout]
+extends = http://dist.plone.org/release/4.3.7/versions.cfg
+
+[versions]
+plone.app.linkintegrity = 1.5.4

--- a/plone4.cfg
+++ b/plone4.cfg
@@ -3,5 +3,3 @@ extends = http://dist.plone.org/release/4.3.7/versions.cfg
 
 [versions]
 plone.app.linkintegrity = 1.5.4
-setuptools = 19.4
-zc.buildout = 2.5.0

--- a/plone4.cfg
+++ b/plone4.cfg
@@ -3,3 +3,5 @@ extends = http://dist.plone.org/release/4.3.7/versions.cfg
 
 [versions]
 plone.app.linkintegrity = 1.5.4
+setuptools = 19.4
+zc.buildout = 2.5.0

--- a/plone5.cfg
+++ b/plone5.cfg
@@ -1,0 +1,2 @@
+[buildout]
+extends = http://dist.plone.org/release/5.0.2/versions.cfg

--- a/setup.py
+++ b/setup.py
@@ -41,10 +41,9 @@ setup(name='collective.mailchimp',
       ],
       extras_require={
           'test': [
+              'mock',  # new, backport from Python 3.3
               'mocker',
               'plone.app.testing',
-              'plone.app.contenttypes',
-              'plone.app.robotframework[debug]',
           ],
       },
       entry_points="""

--- a/setup.py
+++ b/setup.py
@@ -37,13 +37,13 @@ setup(name='collective.mailchimp',
           'Products.CMFPlone',
           'plone.app.portlets',
           'plone.app.registry',
-          'postmonkey',
       ],
       extras_require={
           'test': [
-              'plone.app.testing',
               'mocker',
-              'plone.mocktestcase',
+              'plone.app.testing',
+              'plone.app.contenttypes',
+              'plone.app.robotframework[debug]',
           ],
       },
       entry_points="""

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,6 @@ setup(name='collective.mailchimp',
       extras_require={
           'test': [
               'mock',  # new, backport from Python 3.3
-              'mocker',
               'plone.app.testing',
           ],
       },

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(name='collective.mailchimp',
           'Products.CMFPlone',
           'plone.app.portlets',
           'plone.app.registry',
+          'requests',
       ],
       extras_require={
           'test': [


### PR DESCRIPTION
This includes work done by @jladage, @didrix and me. I myself mostly updated the testing part, though that of course led to a few fixes in the code as well.

- Instead of `postmonkey` with api 1.3 we go to the current api 3.0, without third party code.

- Plone 5 support added, although we still use the old style css registry. Kept compatibility with 4.3.  Updated Travis to test both. Default buildout now uses Plone 5.

- Replaced `mocker` with `mock`, closes issue #13.