### PR TITLE
Remove plone.app.imaging dependency that breaks Plone 5.1 and plone.restapi.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 2.1.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Remove plone.app.imaging dependency in setup.py for Plone 5.1 & plone.restapi compatibility.
+  [timo]
 
 
 2.1.0 (2017-09-12)

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,6 +1,7 @@
 [buildout]
 # Note that the extends config is replaced in .travis.yml.
 extends = plone5.cfg
+index = https://pypi.python.org/simple
 develop = .
 eggs = collective.mailchimp
 parts +=

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,6 @@ setup(
         'Products.CMFPlone',
         'plone.app.portlets',
         'plone.app.registry',
-        'plone.app.imaging',  # needed for controlpanel
         'plone.app.upgrade',
         'requests',
     ],

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ setup(
         'test': [
             'mock',  # new, backport from Python 3.3
             'plone.app.testing',
+            'plone.app.imaging',  # test dependency on Plone 5.0.x only
         ],
     },
     entry_points="""

--- a/src/collective/__init__.py
+++ b/src/collective/__init__.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # See http://peak.telecommunity.com/DevCenter/setuptools#namespace-packages
 try:
     __import__('pkg_resources').declare_namespace(__name__)

--- a/src/collective/mailchimp/__init__.py
+++ b/src/collective/mailchimp/__init__.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from zope.i18nmessageid import MessageFactory
 
 _ = MessageFactory('collective.mailchimp')

--- a/src/collective/mailchimp/browser/controlpanel.py
+++ b/src/collective/mailchimp/browser/controlpanel.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from zope.interface import Invalid
 from z3c.form.interfaces import WidgetActionExecutionError
 from zope.component import getUtility

--- a/src/collective/mailchimp/browser/extender.py
+++ b/src/collective/mailchimp/browser/extender.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from collective.mailchimp.browser.newsletter import NewsletterSubscriberForm
 from zope.publisher.interfaces.browser import IDefaultBrowserLayer
 from zope import schema

--- a/src/collective/mailchimp/browser/newsletter.py
+++ b/src/collective/mailchimp/browser/newsletter.py
@@ -169,7 +169,7 @@ class NewsletterSubscriberForm(extensible.ExtensibleForm, form.Form):
                 Invalid(translated_error_msg)
             )
 
-NewsletterView = wrap_form(NewsletterSubscriberForm) # noqa
+NewsletterView = wrap_form(NewsletterSubscriberForm)  # noqa
 
 
 class UnsubscribeNewsletterForm(extensible.ExtensibleForm, form.Form):

--- a/src/collective/mailchimp/browser/portlet.py
+++ b/src/collective/mailchimp/browser/portlet.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from Acquisition import aq_inner
 from zope.interface import alsoProvides
 from z3c.form.interfaces import IFormLayer

--- a/src/collective/mailchimp/browser/z3cformhelpers.py
+++ b/src/collective/mailchimp/browser/z3cformhelpers.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # This is a copy of the z3cformhelpers.py file from the z3cform branch of
 # plone.app.portlets. As soon as PLIP https://dev.plone.org/ticket/11838
 # has been merged into Plone we can remove this file and import

--- a/src/collective/mailchimp/interfaces.py
+++ b/src/collective/mailchimp/interfaces.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import re
 
 from zope import schema

--- a/src/collective/mailchimp/testing.py
+++ b/src/collective/mailchimp/testing.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import json
 import os
 import re
@@ -96,7 +97,7 @@ class MockRequests(object):
             path = os.path.join(
                 TEST_DATA_DIR, 'member.json')
         else:
-            print('WARNING, unhandled endpoint in test: {0}'.format(endpoint))
+            pass
         if path:
             with open(path) as datafile:
                 text = datafile.read()

--- a/src/collective/mailchimp/tests/test_controlpanel.py
+++ b/src/collective/mailchimp/tests/test_controlpanel.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from plone.app.testing import SITE_OWNER_NAME
 from plone.app.testing import SITE_OWNER_PASSWORD
 from plone.testing.z2 import Browser

--- a/src/collective/mailchimp/tests/test_exceptions.py
+++ b/src/collective/mailchimp/tests/test_exceptions.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import unittest
 
 

--- a/src/collective/mailchimp/tests/test_mock_requests.py
+++ b/src/collective/mailchimp/tests/test_mock_requests.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from collective.mailchimp.testing import \
     COLLECTIVE_MAILCHIMP_INTEGRATION_TESTING
 from collective.mailchimp.testing import DUMMY_API_KEY

--- a/src/collective/mailchimp/tests/test_setup.py
+++ b/src/collective/mailchimp/tests/test_setup.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from collective.mailchimp.testing import \
     COLLECTIVE_MAILCHIMP_INTEGRATION_TESTING
 from Products.CMFCore.utils import getToolByName

--- a/src/collective/mailchimp/upgrades.py
+++ b/src/collective/mailchimp/upgrades.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from Products.CMFCore.utils import getToolByName
 
 from zope.component import getUtility

--- a/src/collective/mailchimp/vocabularies.py
+++ b/src/collective/mailchimp/vocabularies.py
@@ -1,4 +1,4 @@
-
+# -*- coding: utf-8 -*-
 from zope.component import getUtility
 from zope.schema.vocabulary import SimpleVocabulary
 from zope.schema.vocabulary import SimpleTerm


### PR DESCRIPTION
This PR also includes a buildout fix and multiple PEP8 violation fixes. Sorry for the mess.