### PR TITLE
add value_type to registry record

### DIFF
--- a/src/collective/mailchimp/profiles/default/registry.xml
+++ b/src/collective/mailchimp/profiles/default/registry.xml
@@ -4,6 +4,7 @@
      <record name="collective.mailchimp.cache.lists">
         <field type="plone.registry.field.Tuple">
             <title>Mailchimp Lists</title>
+            <value_type type="plone.registry.field.Dict" />
         </field>
     </record>
     <record name="collective.mailchimp.cache.groups">


### PR DESCRIPTION
When testing the addon to include it in a Plone 5.2, I had to add this to be able to install it correctly.