### PR TITLE
Reinitialize the locator when called on a different Plone Site.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,10 @@ New features:
 
 Bug fixes:
 
+- Reinitialize the locator when called on a different Plone Site.
+  Fixes `issue 31 <https://github.com/collective/collective.mailchimp/issues/31>`_.
+  [maurits]
+
 - Register resource bundle so our css is loaded on Plone 5.2 and higher.  [maurits]
 
 - Update portlet template and fix portlet code for Plone 5.2/6. [fredvd]

--- a/src/collective/mailchimp/locator.py
+++ b/src/collective/mailchimp/locator.py
@@ -7,6 +7,7 @@ from collective.mailchimp.interfaces import IMailchimpLocator
 from collective.mailchimp.interfaces import IMailchimpSettings
 from plone.registry.interfaces import IRegistry
 from zope.component import getUtility
+from zope.component.hooks import getSite
 from zope.interface import implementer
 
 import hashlib
@@ -35,15 +36,29 @@ class MailchimpLocator(object):
     key_lists = "collective.mailchimp.cache.lists"
 
     def __init__(self, settings={}):
-        """ Use settings if provided """
+        """ Use settings if provided
+
+        Note that the __init__ method is only called once at startup.
+        settings can only be passed when you directly instantiate a
+        MailchimpLocator, for example in tests.
+        """
         self.registry = None
         self.settings = None
         self.api_root = None
         if settings:
             self.settings = settings
+        self.site_path = ""
 
     def initialize(self):
         """ Load settings from registry and construct api root"""
+        site_path = "/".join(getSite().getPhysicalPath())
+        if self.site_path != site_path:
+            # Settings are for a different Plone Site.
+            # See https://github.com/collective/collective.mailchimp/issues/31
+            self.site_path = site_path
+            self.registry = None
+            self.settings = None
+            self.api_root = None
         if self.registry is None:
             self.registry = getUtility(IRegistry)
         if self.settings is None:


### PR DESCRIPTION
This builds on PR #63 as that fixes the tests.
If I understood correctly, if that PR is merged, then the base of the current PR will automatically be changed to master.

Fixes issue #31. Until now the registry and settings of the locator would be loaded once, the first time that a Plone Site with collective.mailchimp installed accesses it. When you then install the add-on in a second Plone Site in the same Zope instance, they would share the registry and settings. In other words:

- Go to the mailchimp control panel of site 1.
- The details under "MailChimp account" are from the api key of this site.
- Go to the mailchimp control panel of site 2.
- The details under "MailChimp account" are from the api key of the first site.

The reinitializing seems the least impactful way to fix this. The alternative would be to add the locator as persistent utility in each site on install, and I don't like that.