### PR TITLE
Split the controlpanel into two separate pages: settings and data.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,12 @@ Breaking changes:
 
 New features:
 
+- Split the controlpanel into two separate pages: settings and data.
+  Until now, if the settings resulted in an error while fetching the data from mailchimp,
+  you could not fix this because the whole control panel would fail to load.
+  Fixes `issue 26 <https://github.com/collective/collective.mailchimp/issues/26>`_.
+  [maurits]
+
 - Updated tests and infrastructure for Plone 5.2, Python 3.
   Plone 6 should work, but it not tested yet.
   [maurits]

--- a/src/collective/mailchimp/browser/configure.zcml
+++ b/src/collective/mailchimp/browser/configure.zcml
@@ -12,6 +12,13 @@
     class=".controlpanel.MailchimpSettingsControlPanel"
     permission="cmf.ManagePortal"
     />
+  <browser:page
+    name="mailchimp-data"
+    for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+    class=".controlpanel.MailchimpData"
+    template="data.pt"
+    permission="cmf.ManagePortal"
+    />
 
   <!-- Portlet -->
   <include package="plone.app.portlets" />

--- a/src/collective/mailchimp/browser/controlpanel.pt
+++ b/src/collective/mailchimp/browser/controlpanel.pt
@@ -24,112 +24,12 @@
 
     <h1 class="documentFirstHeading" tal:content="view/label">View Title</h1>
 
+    <p><a href=""
+       tal:attributes="href string:$portal_url/@@mailchimp-data"
+       i18n:translate="">View MailChimp data</a></p>
     <div id="layout-contents"
-         class="enableUnloadProtection enableAutoFocus enableFormTabbing enableUnlockProtection"
-         tal:define="account view/mailchimp_account|nothing;
-                     empty string:-">
-      <fieldset id="fieldset-send">
-        <legend id="fieldsetlegend-send" i18n:translate="">Standard</legend>
-        <div id="mailchimp-no-valid-account" class="warning" tal:condition="not:account"
-             i18n:translate="msg_mailchimp_no_account">
-          Your account has not been saved yet or is not valid.
-        </div>
+         class="enableUnloadProtection enableAutoFocus enableFormTabbing enableUnlockProtection">
         <span tal:replace="structure view/contents" />
-      </fieldset>
-      <fieldset id="fieldset-account" tal:condition="account">
-        <legend id="fieldsetlegend-account" i18n:translate="">MailChimp Account</legend>
-        Account
-        <table class="listing">
-          <thead>
-            <tr>
-              <th i18n:translate="">Key</th>
-              <th i18n:translate="">Value</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-               <td i18n:translate="">Username:</td>
-               <td tal:content="account/account_name|empty"/>
-            </tr>
-            <tr>
-              <td i18n:translate="">Last login: </td>
-              <td tal:content="account/last_login|empty"/>
-            </tr>
-            <tr>
-              <td i18n:translate="">Company: </td>
-              <td tal:content="account/contact/company|empty"/>
-            </tr>
-            <tr>
-              <td i18n:translate="">Address 1: </td>
-              <td tal:content="account/contact/addr1|empty"/>
-            </tr>
-            <tr>
-              <td i18n:translate="">Address 2: </td>
-              <td tal:content="account/contact/addr2|empty"/>
-            </tr>
-            <tr>
-              <td i18n:translate="">Zip: </td>
-              <td tal:content="account/contact/zip|empty"/>
-            </tr>
-            <tr>
-              <td i18n:translate="">State: </td>
-              <td tal:content="account/contact/state|empty"/>
-            </tr>
-            <tr>
-               <td i18n:translate="">City: </td>
-              <td tal:content="account/contact/city|empty"/>
-            </tr>
-            <tr>
-              <td i18n:translate="">Country: </td>
-              <td tal:content="account/contact/country|empty"/>
-            </tr>
-           </tbody>
-        </table>
-
-      </fieldset>
-      <fieldset id="fieldset-lists" tal:condition="account">
-        <legend id="fieldsetlegend-preview" i18n:translate="">MailChimp Lists</legend>
-        <table class="listing"
-               tal:define="lists python:view.available_lists()">
-          <thead>
-            <tr>
-              <th i18n:translate="">ID</th>
-              <th i18n:translate="">Name</th>
-              <th i18n:translate="">Member count</th>
-              <th i18n:translate="">Member count since send</th>
-              <th i18n:translate="">Default from name</th>
-              <th i18n:translate="">Default from email</th>
-              <th i18n:translate="">Default subject</th>
-              <th i18n:translate="">Default language</th>
-              <th i18n:translate="">Unsubscribed count</th>
-              <th i18n:translate="">Unsubscribed count since send</th>
-              <th i18n:translate="">Cleaned cound</th>
-              <th i18n:translate="">Cleaned count since send</th>
-              <th i18n:translate="">Date created</th>
-              <th i18n:translate="">List rating</th>
-            </tr>
-          </thead>
-          <tbody tal:repeat="list lists">
-            <tr>
-              <td tal:content="list/id|empty"></td>
-              <td tal:content="list/name|empty"></td>
-              <td tal:content="list/stats/member_count|empty"></td>
-              <td tal:content="list/stats/member_count_since_send|empty"></td>
-              <td tal:content="list/campaign_defaults/from_name|empty"></td>
-              <td tal:content="list/campaign_defaults/from_email|empty"></td>
-              <td tal:content="list/campaign_defaults/subject|empty"></td>
-              <td tal:content="list/campaign_defaults/language|empty"></td>
-              <td tal:content="list/stats/unsubscribe_count|empty"></td>
-              <td tal:content="list/stats/unsubscribe_count_since_send|empty"></td>
-              <td tal:content="list/stats/cleaned_count|empty"></td>
-              <td tal:content="list/stats/cleaned_count_since_send|empty"></td>
-              <td tal:content="list/date_created|empty"></td>
-              <td tal:content="list/list_rating|empty"></td>
-            </tr>
-          </tbody>
-        </table>
-
-      </fieldset>
     </div>
 
     <script type="text/javascript">

--- a/src/collective/mailchimp/browser/controlpanel.py
+++ b/src/collective/mailchimp/browser/controlpanel.py
@@ -6,6 +6,7 @@ from collective.mailchimp.interfaces import IMailchimpLocator
 from collective.mailchimp.interfaces import IMailchimpSettings
 from plone.app.registry.browser import controlpanel
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from Products.Five.browser import BrowserView
 from z3c.form.interfaces import WidgetActionExecutionError
 from zope.component import getUtility
 from zope.interface import alsoProvides
@@ -36,6 +37,8 @@ class MailchimpSettingsEditForm(controlpanel.RegistryEditForm):
         super(MailchimpSettingsEditForm, self).updateWidgets()
 
     def updateCache(self):
+        if IDisableCSRFProtection is not None:
+            alsoProvides(self.request, IDisableCSRFProtection)
         mailchimp = getUtility(IMailchimpLocator)
         mailchimp.updateCache()
 
@@ -43,6 +46,10 @@ class MailchimpSettingsEditForm(controlpanel.RegistryEditForm):
 class MailchimpSettingsControlPanel(controlpanel.ControlPanelFormWrapper):
     form = MailchimpSettingsEditForm
     index = ViewPageTemplateFile('controlpanel.pt')
+
+
+class MailchimpData(BrowserView):
+    label = _(u"MailChimp data")
 
     def mailchimp_account(self):
         if IDisableCSRFProtection is not None:

--- a/src/collective/mailchimp/browser/data.pt
+++ b/src/collective/mailchimp/browser/data.pt
@@ -1,0 +1,136 @@
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      lang="en"
+      metal:use-macro="here/prefs_main_template/macros/master"
+      i18n:domain="collective.mailchimp">
+
+<body>
+
+  <div id="content"
+     metal:fill-slot="prefs_configlet_content">
+
+    <div metal:use-macro="context/global_statusmessage/macros/portal_message">
+      Portal status message
+    </div>
+
+    <a href=""
+       id="setup-link"
+       tal:attributes="href string:$portal_url/@@overview-controlpanel"
+       i18n:translate="">
+        Site Setup
+    </a> &rsaquo;
+
+    <h1 class="documentFirstHeading" tal:content="view/label">View Title</h1>
+    <p><a href=""
+      tal:attributes="href string:$portal_url/@@mailchimp-settings"
+      i18n:translate="">View MailChimp settings</a></p>
+
+    <div id="layout-contents"
+         class="enableUnloadProtection enableAutoFocus enableFormTabbing enableUnlockProtection"
+         tal:define="account view/mailchimp_account|nothing;
+                     empty string:-">
+      <div id="mailchimp-no-valid-account" class="warning" tal:condition="not:account"
+            i18n:translate="msg_mailchimp_no_account">
+        Your account has not been saved yet or is not valid.
+      </div>
+      <fieldset id="fieldset-account" tal:condition="account">
+        <legend id="fieldsetlegend-account" i18n:translate="">MailChimp Account</legend>
+        Account
+        <table class="listing">
+          <thead>
+            <tr>
+              <th i18n:translate="">Key</th>
+              <th i18n:translate="">Value</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+               <td i18n:translate="">Username:</td>
+               <td tal:content="account/account_name|empty"/>
+            </tr>
+            <tr>
+              <td i18n:translate="">Last login: </td>
+              <td tal:content="account/last_login|empty"/>
+            </tr>
+            <tr>
+              <td i18n:translate="">Company: </td>
+              <td tal:content="account/contact/company|empty"/>
+            </tr>
+            <tr>
+              <td i18n:translate="">Address 1: </td>
+              <td tal:content="account/contact/addr1|empty"/>
+            </tr>
+            <tr>
+              <td i18n:translate="">Address 2: </td>
+              <td tal:content="account/contact/addr2|empty"/>
+            </tr>
+            <tr>
+              <td i18n:translate="">Zip: </td>
+              <td tal:content="account/contact/zip|empty"/>
+            </tr>
+            <tr>
+              <td i18n:translate="">State: </td>
+              <td tal:content="account/contact/state|empty"/>
+            </tr>
+            <tr>
+               <td i18n:translate="">City: </td>
+              <td tal:content="account/contact/city|empty"/>
+            </tr>
+            <tr>
+              <td i18n:translate="">Country: </td>
+              <td tal:content="account/contact/country|empty"/>
+            </tr>
+           </tbody>
+        </table>
+
+      </fieldset>
+      <fieldset id="fieldset-lists" tal:condition="account">
+        <legend id="fieldsetlegend-preview" i18n:translate="">MailChimp Lists</legend>
+        <table class="listing"
+               tal:define="lists python:view.available_lists()">
+          <thead>
+            <tr>
+              <th i18n:translate="">ID</th>
+              <th i18n:translate="">Name</th>
+              <th i18n:translate="">Member count</th>
+              <th i18n:translate="">Member count since send</th>
+              <th i18n:translate="">Default from name</th>
+              <th i18n:translate="">Default from email</th>
+              <th i18n:translate="">Default subject</th>
+              <th i18n:translate="">Default language</th>
+              <th i18n:translate="">Unsubscribed count</th>
+              <th i18n:translate="">Unsubscribed count since send</th>
+              <th i18n:translate="">Cleaned cound</th>
+              <th i18n:translate="">Cleaned count since send</th>
+              <th i18n:translate="">Date created</th>
+              <th i18n:translate="">List rating</th>
+            </tr>
+          </thead>
+          <tbody tal:repeat="list lists">
+            <tr>
+              <td tal:content="list/id|empty"></td>
+              <td tal:content="list/name|empty"></td>
+              <td tal:content="list/stats/member_count|empty"></td>
+              <td tal:content="list/stats/member_count_since_send|empty"></td>
+              <td tal:content="list/campaign_defaults/from_name|empty"></td>
+              <td tal:content="list/campaign_defaults/from_email|empty"></td>
+              <td tal:content="list/campaign_defaults/subject|empty"></td>
+              <td tal:content="list/campaign_defaults/language|empty"></td>
+              <td tal:content="list/stats/unsubscribe_count|empty"></td>
+              <td tal:content="list/stats/unsubscribe_count_since_send|empty"></td>
+              <td tal:content="list/stats/cleaned_count|empty"></td>
+              <td tal:content="list/stats/cleaned_count_since_send|empty"></td>
+              <td tal:content="list/date_created|empty"></td>
+              <td tal:content="list/list_rating|empty"></td>
+            </tr>
+          </tbody>
+        </table>
+
+      </fieldset>
+    </div>
+
+  </div>
+</body>
+</html>


### PR DESCRIPTION
This is based on the branch from PR #64, which fixes the locator and the tests, though technically this fix is unrelated.

Until now, if the settings resulted in an error while fetching the data from mailchimp, you could not fix this because the whole control panel would fail to load. Fixes issue #26.

The control panel with the settings now has a link to new `@@mailchimp-data`, and this has a link back to the mailchimp control panel.