### PR TITLE
Catch more errors

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,10 @@ New features:
 
 Bug fixes:
 
+- Handle all exceptions when subscribing or unsubscribing.
+  Otherwise you will keep seeing the form and never see an error.
+  [maurits]
+
 - Raise BadRequest error when the list id is illegal.
   This tries to avoid hacking attempts that can get you banned.
   [maurits]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,10 @@ New features:
 
 Bug fixes:
 
+- Raise BadRequest error when the list id is illegal.
+  This tries to avoid hacking attempts that can get you banned.
+  [maurits]
+
 - Catch 503 error from Akamai, which is an upstream provider for MailChimp.
   You get this when you are (temporarily) blocked.
   [maurits]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,12 @@ New features:
 
 - Test on Plone 6.0 as well, next to Plone 5.2.  [maurits]
 
+Bug fixes:
+
+- Catch 503 error from Akamai, which is an upstream provider for MailChimp.
+  You get this when you are (temporarily) blocked.
+  [maurits]
+
 
 4.0.0a1 (2023-04-14)
 --------------------

--- a/src/collective/mailchimp/exceptions.py
+++ b/src/collective/mailchimp/exceptions.py
@@ -56,3 +56,23 @@ class MailChimpException(Exception):
         return 'MailChimp error code {0}: "{1}"\n{2}'.format(
             self.code, self.detail, self.errors
         )
+
+
+class AkamaiException(MailChimpException):
+    """Akamai is an provider upstream for MailChimp.
+
+    It may give 503 code if you are blocked.  Sample:
+
+    {'type': 'akamai_error_message', 'title': 'akamai_503', 'status': 503,
+     'ref_no': 'Reference Number: ...'}
+    """
+
+    def __init__(self, code, detail, errors=''):
+        self.code = code
+        self.detail = detail
+        self.errors = errors
+
+    def __str__(self):
+        return 'Akamai error code {0}: "{1}"\n{2}'.format(
+            self.code, self.detail, self.errors
+        )

--- a/src/collective/mailchimp/locator.py
+++ b/src/collective/mailchimp/locator.py
@@ -288,7 +288,7 @@ class MailchimpLocator(object):
         except MailChimpException:
             raise
         except Exception as e:
-           raise PostRequestError(e)
+            raise PostRequestError(e)
         logger.info(
             "Subscribed %s to list with id: %s." % (email_address, list_id)
         )

--- a/src/collective/mailchimp/tests/test_unit.py
+++ b/src/collective/mailchimp/tests/test_unit.py
@@ -1,0 +1,19 @@
+
+import unittest
+
+
+class TestUnit(unittest.TestCase):
+    def test_list_id_allowed(self):
+        from collective.mailchimp.browser.newsletter import CHARS_ALLOWED as allowed
+
+        self.assertTrue(allowed("abcde12345"))
+        self.assertTrue(allowed("12345ABCDE"))
+        self.assertTrue(allowed("4f17c3b08a"))
+        self.assertTrue(allowed("html"))
+        self.assertTrue(allowed("plain-text"))
+        self.assertTrue(allowed("text/plain"))
+        self.assertTrue(allowed("maurits@example.org"))
+        self.assertTrue(allowed("maurits+test@example.org"))
+        self.assertFalse(allowed("abcde1234' hack em"))
+        self.assertFalse(allowed("abcde1234;"))
+        self.assertFalse(allowed("abcde1234?"))


### PR DESCRIPTION
* Raise BadRequest error when the list id or other form data is illegal.  This tries to avoid hacking attempts that can get you banned.
* Catch 503 error from Akamai, which is an upstream provider for MailChimp.  You get this when you are (temporarily) blocked.  Guess what happened today.